### PR TITLE
Add Github Actions CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "gradle"
+    directory: "/android"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
       # 打包 apk
       - name: Collect Apks
         if: matrix.target == 'android'
-        run: flutter build apk --release --split-per-abi
+        run: flutter build apk -t lib/src/main.dart --release --split-per-abi
 #        env:
 #          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
 #          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
@@ -146,7 +146,7 @@ jobs:
         if: matrix.target == 'ios'
         run: |
           cd ios && pod update && pod install && cd ..
-          flutter build ios --release --no-codesign
+          flutter build ios -t lib/src/main.dart --release --no-codesign
       - name: Thin app
         if: matrix.target == 'ios'
         run: sh thin-payload.sh build/ios/iphoneos/*.app
@@ -164,7 +164,7 @@ jobs:
         if: matrix.target == 'macos'
         run: |
           cd macos && pod update && pod install && cd ..
-          flutter build macos --release
+          flutter build macos -t lib/src/main.dart --release
           APP_PATH=build/macos/Build/Products/Release/jhentai.app
           cp -a $APP_PATH ./build
           cd build && zip -qroy macos/JHenTai_macos.zip jhentai.app
@@ -172,7 +172,7 @@ jobs:
       - name: Build windows
         if: matrix.target == 'windows'
         run: |
-          flutter build windows --release
+          flutter build windows -t lib/src/main.dart --release
           $DestDir = "build\windows\JHenTai"
           $SrcDir = "build\windows\runner\Release"
           New-Item -Path $DestDir -ItemType Directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,210 @@
+name: Build Release
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - v*
+
+jobs:
+  Build_and_upload:
+    name: Build releases
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: android
+            os: ubuntu-latest
+            flutter_version: '3.3.1'
+            artifact_name: release-apk
+            artifact_path: build/app/outputs/apk/release/*.apk
+          - target: ios
+            os: macos-latest
+            flutter_version: '3.3.1'
+            artifact_name: release-ios
+            artifact_path: build/**/*.ipa
+          - target: macos
+            os: macos-latest
+            flutter_version: '3.3.1'
+            artifact_name: release-mac
+            artifact_path: build/macos/*.zip
+          - target: windows
+            os: windows-latest
+            flutter_version: '3.3.1'
+            artifact_name: release-windows
+            artifact_path: build/windows/*.zip
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+
+      - name: Cache Flutter (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.lock') }}
+          path: /opt/hostedtoolcache/flutter
+          restore-keys: |
+            ${{ runner.os }}-flutter-
+
+      - name: Cache Flutter (MacOS)
+        if: matrix.os == 'macos-latest'
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.lock') }}
+          path: /Users/runner/hostedtoolcache/flutter
+          restore-keys: |
+            ${{ runner.os }}-flutter-
+
+      - name: Cache Flutter (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.lock') }}
+          path: 'C:\hostedtoolcache\windows\flutter'
+          restore-keys: |
+            ${{ runner.os }}-flutter-
+
+      - name: Cache Gradle packages (Android)
+        if: matrix.target == 'android'
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Cache Pods (build macos)
+        uses: actions/cache@v3
+        if: matrix.target == 'macos'
+        with:
+          path: |
+            macos/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('macos/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
+      - name: Cache Pods (build ios)
+        uses: actions/cache@v3
+        if: matrix.target == 'ios'
+        with:
+          path: |
+            ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-            
+
+
+#      - name: Decode keystore
+#        if: matrix.target == 'android'
+#        run: |
+#          echo $ENCODED_KEYSTORE | base64 -di > android/app/keystore.jks
+#        env:
+#          ENCODED_KEYSTORE: ${{ secrets.ENCODED_KEYSTORE }}
+
+      # 安装 JDK
+      - name: Setup Java JDK 11 (Android)
+        if: matrix.target == 'android'
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+          cache: gradle
+
+      # 安装 Flutter
+      - name: Flutter action
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ matrix.flutter_version }}
+
+      - name: Build resolve Swift dependencies
+        if: matrix.os == 'macos-latest'
+        run: xcodebuild -resolvePackageDependencies -workspace ios/Runner.xcworkspace -scheme Runner -configuration Release
+
+      - name: Flutter pub get
+        run: |
+          git config --global core.longpaths true
+          flutter pub get
+
+      # 打包 apk
+      - name: Collect Apks
+        if: matrix.target == 'android'
+        run: flutter build apk --release --split-per-abi
+#        env:
+#          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+#          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+#          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD}}
+
+      # 打包 ipa
+      - name: Build ios app
+        if: matrix.target == 'ios'
+        run: |
+          cd ios && pod update && pod install && cd ..
+          flutter build ios --release --no-codesign
+      - name: Thin app
+        if: matrix.target == 'ios'
+        run: sh thin-payload.sh build/ios/iphoneos/*.app
+
+      - name: Build ipa file
+        if: matrix.target == 'ios'
+        run: |
+          cd build
+          mkdir -p Payload
+          mv ios/iphoneos/*.app Payload
+          zip -9 JHenTai.ipa -r Payload
+
+      # 打包 mac
+      - name: Build mac app
+        if: matrix.target == 'macos'
+        run: |
+          cd macos && pod update && pod install && cd ..
+          flutter build macos --release
+          APP_PATH=build/macos/Build/Products/Release/jhentai.app
+          cp -a $APP_PATH ./build
+          cd build && zip -qroy macos/JHenTai_macos.zip jhentai.app
+
+      - name: Build windows
+        if: matrix.target == 'windows'
+        run: |
+          flutter build windows --release
+          $DestDir = "build\windows\JHenTai"
+          $SrcDir = "build\windows\runner\Release"
+          New-Item -Path $DestDir -ItemType Directory
+          Copy-Item $SrcDir\* -Recurse $DestDir
+          Copy-Item -Filter *.dll -Path windows\* -Destination $DestDir -Force
+          Compress-Archive $DestDir build\windows\JHenTai_windows.zip
+
+      - name: Publish Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.artifact_path }}
+
+  Publish_releases:
+    if: startsWith(github.ref, 'refs/tag/')
+    name: Publish releases
+    needs: Build_and_upload
+    runs-on: ubuntu-latest
+    steps:
+      - run: mkdir /tmp/artifacts
+      - name: Download all Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: /tmp/artifacts
+
+      - run: ls -R /tmp/artifacts
+
+#      - name: Upload to release
+#        uses: ncipollo/release-action@v1
+#        with:
+#          artifacts: "/tmp/artifacts/release-apk/*.apk,/tmp/artifacts/release-ios/*.ipa,/tmp/artifacts/release-mac/*.zip,/tmp/artifacts/release-windows/*.zip"
+#          tag: ${{ github.ref_name }}
+#          prerelease: true
+#          allowUpdates: true
+#          token: ${{ secrets.RELEASE_TOKEN }}

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+android.jetifier.blacklist=bcprov-jdk15on

--- a/thin-payload.sh
+++ b/thin-payload.sh
@@ -1,0 +1,28 @@
+# 精简Payload文件夹 (上传到AppStore会自动区分平台, 此代码仅用于构建非签名ipa)
+
+foreachThin(){
+  for file in $1/*
+  do
+      if test -f $file
+      then
+           mime=$(file --mime-type -b $file)
+           if [ "$mime" == 'application/x-mach-binary' ]  || [ "${file##*.}"x = "dylib"x ]
+           then
+                echo thin $file
+                xcrun -sdk iphoneos lipo "$file" -thin arm64 -output "$file"
+                xcrun -sdk iphoneos bitcode_strip "$file" -r -o  "$file"
+                strip -S -x "$file" -o "$file"
+           fi
+      fi
+      if test -d $file
+      then
+          foreachThin $file
+      fi
+  done
+}
+
+if [ $# eq 0 ]; then
+  ehco "no argument"
+else
+  foreachThin $1
+fi


### PR DESCRIPTION
添加了Actions的自动构建脚本，触发条件是每次推送，如果推送的是v开头的tag，会发prerelease，否则只构建artifacts
---
- apk构建因为原gradle就没指定keystore的地方，所以保留，也就是可能会每次都自动生成新的密钥？如果需要固定签名密钥后续还需要修改
- ipa使用无签名构建，再使用证书重新自签就能使用
- win和maos估计没什么大问题
- 发布relese的job在末尾，目前注释掉了，因为需要github TOKEN
构建结果参考[这里](https://github.com/honjow/JHenTai/actions/runs/3030813191)

