### PR TITLE
fix system navigation bar color transparent

### DIFF
--- a/android/app/src/main/kotlin/top/jtmonster/jhentai/MainActivity.kt
+++ b/android/app/src/main/kotlin/top/jtmonster/jhentai/MainActivity.kt
@@ -1,5 +1,8 @@
 package top.jtmonster.jhentai
 
+import android.os.Build
+import android.os.Bundle
+import androidx.core.view.WindowCompat
 import io.flutter.embedding.android.FlutterFragmentActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugins.GeneratedPluginRegistrant
@@ -7,5 +10,17 @@ import io.flutter.plugins.GeneratedPluginRegistrant
 class MainActivity: FlutterFragmentActivity() {
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         GeneratedPluginRegistrant.registerWith(flutterEngine)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), false)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            // Disable the Android splash screen fade out animation to avoid
+            // a flicker before the similar frame is drawn in Flutter.
+            splashScreen.setOnExitAnimationListener { splashScreenView -> splashScreenView.remove() }
+        }
+
+        super.onCreate(savedInstanceState)
     }
 }

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -5,7 +5,7 @@
         <!-- Show a splash screen on the activity. Automatically removed when
              Flutter draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
-        <item name="android:windowTranslucentNavigation">true</item>
+<!--        <item name="android:windowTranslucentNavigation">true</item>-->
     </style>
     <!-- Theme applied to the Android Window as soon as the process has started.
          This theme determines the color of the Android Window while your
@@ -14,8 +14,8 @@
 
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
     <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
-        <item name="android:windowBackground">@android:color/transparent</item>
-        <item name="android:windowTranslucentNavigation">true</item>
+<!--        <item name="android:windowBackground">@android:color/transparent</item>-->
+<!--        <item name="android:windowTranslucentNavigation">true</item>-->
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
     </style>
 </resources>

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:bitsdojo_window/bitsdojo_window.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:get/get.dart';
 import 'package:jhentai/src/config/sentry_config.dart';
@@ -86,6 +87,12 @@ class MyApp extends StatelessWidget {
 }
 
 Future<void> init() async {
+  SystemChrome.setSystemUIOverlayStyle(const SystemUiOverlayStyle(
+    systemNavigationBarColor: Colors.transparent,
+    systemNavigationBarDividerColor: Colors.transparent,
+    statusBarColor: Colors.transparent,
+  ));
+
   FlutterError.onError = (FlutterErrorDetails details) {
     Log.error(details.exception, null, details.stack);
     Log.upload(details.exception, stackTrace: details.stack);

--- a/lib/src/pages/read/read_page.dart
+++ b/lib/src/pages/read/read_page.dart
@@ -36,7 +36,14 @@ class ReadPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AnnotatedRegion<SystemUiOverlayStyle>(
-      value: SystemUiOverlayStyle.light,
+      value: const SystemUiOverlayStyle(
+        systemNavigationBarColor: Colors.transparent,
+        systemNavigationBarDividerColor: Colors.transparent,
+        statusBarColor: Colors.transparent,
+        systemNavigationBarIconBrightness: Brightness.light,
+        statusBarIconBrightness: Brightness.light,
+        statusBarBrightness: Brightness.dark,
+      ),
       child: ScrollConfiguration(
         behavior: GetPlatform.isDesktop ? UIConfig.behaviorWithScrollBar : UIConfig.behaviorWithoutScrollBar,
         child: EHKeyboardListener(


### PR DESCRIPTION
优化Android上导航栏、手势条的透明效果
MainActivity添加  `WindowCompat.setDecorFitsSystemWindows(getWindow(), false)` 处理，全屏化
使用 `SystemChrome.setSystemUIOverlayStyle` 设置背景色
手势条背景现在应该是完全透明的了，不过虚拟键方式的话好像是因为google限制，不能完全透明。
原生系统和OneUI测试都ok