### PR TITLE
Use only one cache for android

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,16 +69,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-flutter-
 
-      - name: Cache Gradle packages (Android)
-        if: matrix.target == 'android'
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+#       - name: Cache Gradle packages (Android)
+#         if: matrix.target == 'android'
+#         uses: actions/cache@v3
+#         with:
+#           path: |
+#             ~/.gradle/caches
+#             ~/.gradle/wrapper
+#           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+#           restore-keys: |
+#             ${{ runner.os }}-gradle-
 
       - name: Cache Pods (build macos)
         uses: actions/cache@v3


### PR DESCRIPTION
actions/setup-java也对gradle缓存了一次，不必再通过actions/cache现式缓存一次。