### PR TITLE
tweaks to handle more galleries

### DIFF
--- a/lib/src/pages/download/download_base_page.dart
+++ b/lib/src/pages/download/download_base_page.dart
@@ -217,7 +217,7 @@ class _GroupListState<E, G> extends State<GroupList<E, G>> {
         controller: scrollController,
         padding: const EdgeInsets.only(bottom: 80),
         itemCount: widget.elements.length + widget.groups.length,
-        cacheExtent: 6000,
+        cacheExtent: 20,
         itemBuilder: (BuildContext context, int index) {
           int remainingCount = index;
           int groupIndex = 0;

--- a/lib/src/service/archive_download_service.dart
+++ b/lib/src/service/archive_download_service.dart
@@ -335,11 +335,11 @@ class ArchiveDownloadService extends GetxController with GridBasePageServiceMixi
         continue;
       }
 
-      _initArchiveInMemory(archive);
+      _initArchiveInMemory(archive, sort: false);
 
       restoredCount++;
     }
-
+    _sortArchives();
     return restoredCount;
   }
 
@@ -697,8 +697,9 @@ class ArchiveDownloadService extends GetxController with GridBasePageServiceMixi
     List<ArchiveDownloadedData> archives = await appDb.selectArchives().get();
 
     for (ArchiveDownloadedData archive in archives) {
-      _initArchiveInMemory(archive);
+      _initArchiveInMemory(archive, sort: false);
     }
+    _sortArchives();
   }
 
   Future<bool> _initArchiveInfo(ArchiveDownloadedData archive) async {
@@ -775,7 +776,7 @@ class ArchiveDownloadService extends GetxController with GridBasePageServiceMixi
 
   // MEMORY
 
-  void _initArchiveInMemory(ArchiveDownloadedData archive) {
+  void _initArchiveInMemory(ArchiveDownloadedData archive, {bool sort = true}) {
     if (!allGroups.contains(archive.groupName ?? 'default'.tr)) {
       allGroups.add(archive.groupName ?? 'default'.tr);
     }
@@ -794,7 +795,7 @@ class ArchiveDownloadService extends GetxController with GridBasePageServiceMixi
       group: archive.groupName ?? 'default'.tr,
     );
 
-    _sortArchives();
+    if (sort) _sortArchives();
     update([galleryCountChangedId, '$archiveStatusId::::${archive.gid}']);
   }
 

--- a/lib/src/service/gallery_download_service.dart
+++ b/lib/src/service/gallery_download_service.dart
@@ -431,11 +431,11 @@ class GalleryDownloadService extends GetxController with GridBasePageServiceMixi
         continue;
       }
 
-      _initGalleryInfoInMemory(gallery, images: images);
+      _initGalleryInfoInMemory(gallery, images: images, sort: false);
 
       restoredCount++;
     }
-
+    _sortGallerys();
     return restoredCount;
   }
 


### PR DESCRIPTION
Make #308 further.

It should handle this now:

![image](https://github.com/jiangtian616/JHenTai/assets/7552030/2b7c2bc4-37ed-4457-bcf9-fe31a738bddb)

### What's more

List mode can still be laggy if you swiping across huge groups, it needs a redesign to reach the baseline of a reasonable performance.