### PR TITLE
Support 2-finger touchpad gesture and Ctrl+mouse wheel to zoom

### DIFF
--- a/lib/src/config/ui_config.dart
+++ b/lib/src/config/ui_config.dart
@@ -397,6 +397,7 @@ class UIConfig {
   /// Read page
   static const Color readPageBackGroundColor = Colors.black;
   static const Color readPageForeGroundColor = Colors.white;
+  static const double readPageMaxScale = 3.0;
 
   static Color get readPageMenuColor => Colors.black.withOpacity(0.85);
 

--- a/lib/src/pages/read/layout/base/base_layout_logic.dart
+++ b/lib/src/pages/read/layout/base/base_layout_logic.dart
@@ -64,6 +64,10 @@ abstract class BaseLayoutLogic extends GetxController with GetTickerProviderStat
     super.onClose();
   }
 
+  PhotoViewController? get photoViewController => null;
+
+  double? _lastScale;
+
   /// Tap left region or click right arrow key. If read direction is right-to-left, we should call [toNext], otherwise [toPrev]
   void toLeft();
 
@@ -96,6 +100,9 @@ abstract class BaseLayoutLogic extends GetxController with GetTickerProviderStat
   }
 
   PhotoViewScaleState scaleStateCycle(PhotoViewScaleState actual) {
+    if (photoViewController?.scale != 1.0) {
+      return PhotoViewScaleState.initial;
+    }
     switch (actual) {
       case PhotoViewScaleState.initial:
         return PhotoViewScaleState.zoomedIn;
@@ -114,11 +121,39 @@ abstract class BaseLayoutLogic extends GetxController with GetTickerProviderStat
   }
 
   void onPointerScroll(PointerScrollEvent value) {
+    if (HardwareKeyboard.instance.isControlPressed) {
+      final double delta = value.scrollDelta.dy;
+      final double scaleDelta = delta > 0 ? 0.95 : 1.05;
+      handleScale(scaleDelta);
+      return;
+    }
     if (value.scrollDelta.dy > 0) {
       toNext();
     } else if (value.scrollDelta.dy < 0) {
       toPrev();
     }
+  }
+
+  void onPointerPanZoomStart(PointerPanZoomStartEvent event) {
+    _lastScale = photoViewController?.scale;
+  }
+
+  void onPointerPanZoomUpdate(PointerPanZoomUpdateEvent event) {
+    if (photoViewController == null || _lastScale == null) {
+      return;
+    }
+    photoViewController!.scale = (_lastScale! * event.scale).clamp(1.0, 2.5);
+  }
+
+  void onPointerPanZoomEnd(PointerPanZoomEndEvent event) {
+    _lastScale = null;
+  }
+
+  void handleScale(double scaleDelta) {
+    if (photoViewController == null) {
+      return;
+    }
+    photoViewController!.scale = (photoViewController!.scale! * scaleDelta).clamp(1.0, 2.5);
   }
 
   void showBottomMenuInOnlineMode(int index, BuildContext context) {

--- a/lib/src/pages/read/layout/base/base_layout_logic.dart
+++ b/lib/src/pages/read/layout/base/base_layout_logic.dart
@@ -14,6 +14,7 @@ import 'package:get/get_navigation/get_navigation.dart';
 import 'package:get/get_rx/get_rx.dart';
 import 'package:get/get_state_manager/get_state_manager.dart';
 import 'package:get/get_utils/get_utils.dart';
+import 'package:jhentai/src/config/ui_config.dart';
 import 'package:jhentai/src/extension/get_logic_extension.dart';
 import 'package:jhentai/src/network/eh_request.dart';
 import 'package:jhentai/src/service/gallery_download_service.dart';
@@ -142,7 +143,7 @@ abstract class BaseLayoutLogic extends GetxController with GetTickerProviderStat
     if (photoViewController == null || _lastScale == null) {
       return;
     }
-    photoViewController!.scale = (_lastScale! * event.scale).clamp(1.0, 2.5);
+    photoViewController!.scale = (_lastScale! * event.scale).clamp(1.0, UIConfig.readPageMaxScale);
   }
 
   void onPointerPanZoomEnd(PointerPanZoomEndEvent event) {
@@ -153,7 +154,7 @@ abstract class BaseLayoutLogic extends GetxController with GetTickerProviderStat
     if (photoViewController == null) {
       return;
     }
-    photoViewController!.scale = (photoViewController!.scale! * scaleDelta).clamp(1.0, 2.5);
+    photoViewController!.scale = (photoViewController!.scale! * scaleDelta).clamp(1.0, UIConfig.readPageMaxScale);
   }
 
   void showBottomMenuInOnlineMode(int index, BuildContext context) {

--- a/lib/src/pages/read/layout/horizontal_double_column/horizontal_double_column_layout.dart
+++ b/lib/src/pages/read/layout/horizontal_double_column/horizontal_double_column_layout.dart
@@ -5,6 +5,7 @@ import 'package:get/get.dart';
 import 'package:jhentai/src/extension/get_logic_extension.dart';
 import 'package:jhentai/src/model/read_page_info.dart';
 import 'package:jhentai/src/pages/read/layout/horizontal_double_column/horizontal_double_column_layout_state.dart';
+import 'package:jhentai/src/config/ui_config.dart';
 import 'package:jhentai/src/widget/eh_wheel_scroll_listener.dart';
 import 'package:photo_view/photo_view_gallery.dart';
 
@@ -38,7 +39,7 @@ class HorizontalDoubleColumnLayout extends BaseLayout {
                 controller: state.photoViewController,
                 initialScale: 1.0,
                 minScale: 1.0,
-                maxScale: 2.5,
+                maxScale: UIConfig.readPageMaxScale,
                 child: PhotoViewGallery.builder(
                   scrollPhysics: const ClampingScrollPhysics(),
                   pageController: state.pageController,
@@ -50,7 +51,7 @@ class HorizontalDoubleColumnLayout extends BaseLayout {
                   builder: (context, index) => PhotoViewGalleryPageOptions.customChild(
                     initialScale: 1.0,
                     minScale: 1.0,
-                    maxScale: 2.5,
+                    maxScale: UIConfig.readPageMaxScale,
                     scaleStateCycle: readSetting.enableDoubleTapToScaleUp.isTrue ? logic.scaleStateCycle : null,
                     enableTapDragZoom: readSetting.enableTapDragToScaleUp.isTrue,
                     child: index < 0 || index >= state.pageCount

--- a/lib/src/pages/read/layout/horizontal_double_column/horizontal_double_column_layout.dart
+++ b/lib/src/pages/read/layout/horizontal_double_column/horizontal_double_column_layout.dart
@@ -25,29 +25,41 @@ class HorizontalDoubleColumnLayout extends BaseLayout {
   Widget buildBody(BuildContext context) {
     return EHWheelListener(
       onPointerScroll: logic.onPointerScroll,
+      onPointerPanZoomStart: logic.onPointerPanZoomStart,
+      onPointerPanZoomUpdate: logic.onPointerPanZoomUpdate,
+      onPointerPanZoomEnd: logic.onPointerPanZoomEnd,
       child: FutureBuilder(
         future: logic.initCompleter.future,
         builder: (context, snapshot) {
           if (snapshot.connectionState == ConnectionState.done) {
             return PhotoViewGallery.builder(
-              scrollPhysics: const ClampingScrollPhysics(),
-              pageController: state.pageController,
-              cacheExtent: readPageState.readPageInfo.mode == ReadMode.online
-                  ? (readSetting.preloadPageCount.value.toDouble() + 1) / 2
-                  : (readSetting.preloadPageCountLocal.value.toDouble() + 1) / 2,
-              reverse: readSetting.isInRight2LeftDirection,
-              itemCount: state.pageCount,
+              itemCount: 1,
               builder: (context, index) => PhotoViewGalleryPageOptions.customChild(
+                controller: state.photoViewController,
                 initialScale: 1.0,
                 minScale: 1.0,
                 maxScale: 2.5,
-                scaleStateCycle: readSetting.enableDoubleTapToScaleUp.isTrue ? logic.scaleStateCycle : null,
-                enableTapDragZoom: readSetting.enableTapDragToScaleUp.isTrue,
-                child: index < 0 || index >= state.pageCount
-                    ? null
-                    : readPageState.readPageInfo.mode == ReadMode.online
-                        ? _buildDoubleColumnItemInOnlineMode(context, index)
-                        : _buildDoubleColumnItemInLocalMode(context, index),
+                child: PhotoViewGallery.builder(
+                  scrollPhysics: const ClampingScrollPhysics(),
+                  pageController: state.pageController,
+                  cacheExtent: readPageState.readPageInfo.mode == ReadMode.online
+                      ? (readSetting.preloadPageCount.value.toDouble() + 1) / 2
+                      : (readSetting.preloadPageCountLocal.value.toDouble() + 1) / 2,
+                  reverse: readSetting.isInRight2LeftDirection,
+                  itemCount: state.pageCount,
+                  builder: (context, index) => PhotoViewGalleryPageOptions.customChild(
+                    initialScale: 1.0,
+                    minScale: 1.0,
+                    maxScale: 2.5,
+                    scaleStateCycle: readSetting.enableDoubleTapToScaleUp.isTrue ? logic.scaleStateCycle : null,
+                    enableTapDragZoom: readSetting.enableTapDragToScaleUp.isTrue,
+                    child: index < 0 || index >= state.pageCount
+                        ? null
+                        : readPageState.readPageInfo.mode == ReadMode.online
+                            ? _buildDoubleColumnItemInOnlineMode(context, index)
+                            : _buildDoubleColumnItemInLocalMode(context, index),
+                  ),
+                ),
               ),
             );
           }

--- a/lib/src/pages/read/layout/horizontal_double_column/horizontal_double_column_layout_logic.dart
+++ b/lib/src/pages/read/layout/horizontal_double_column/horizontal_double_column_layout_logic.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
+import 'package:photo_view/photo_view.dart';
 import 'package:jhentai/src/enum/config_enum.dart';
 import 'package:jhentai/src/extension/get_logic_extension.dart';
 import 'package:jhentai/src/service/local_config_service.dart';
@@ -15,6 +16,9 @@ import 'horizontal_double_column_layout_state.dart';
 
 class HorizontalDoubleColumnLayoutLogic extends BaseLayoutLogic {
   HorizontalDoubleColumnLayoutState state = HorizontalDoubleColumnLayoutState();
+
+  @override
+  PhotoViewController get photoViewController => state.photoViewController;
 
   Completer<void> initCompleter = Completer<void>();
 

--- a/lib/src/pages/read/layout/horizontal_double_column/horizontal_double_column_layout_state.dart
+++ b/lib/src/pages/read/layout/horizontal_double_column/horizontal_double_column_layout_state.dart
@@ -1,8 +1,9 @@
 import 'dart:async';
-
 import 'package:flutter/cupertino.dart';
+import 'package:photo_view/photo_view.dart';
 
 class HorizontalDoubleColumnLayoutState {
+  final PhotoViewController photoViewController = PhotoViewController();
   late PageController pageController;
 
   late int pageCount;

--- a/lib/src/pages/read/layout/horizontal_list/horizontal_list_layout.dart
+++ b/lib/src/pages/read/layout/horizontal_list/horizontal_list_layout.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:jhentai/src/pages/read/layout/horizontal_list/horizontal_list_layout_state.dart';
+import 'package:jhentai/src/widget/eh_wheel_scroll_listener.dart';
 import 'package:photo_view/photo_view_gallery.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import 'package:zoom_view/zoom_view.dart';
@@ -23,7 +24,12 @@ class HorizontalListLayout extends BaseLayout {
   @override
   Widget buildBody(BuildContext context) {
     /// user PhotoViewGallery to scale up the whole gallery list, so set itemCount to 1
-    return PhotoViewGallery.builder(
+    return EHWheelListener(
+      onPointerScroll: logic.onPointerScroll,
+      onPointerPanZoomStart: logic.onPointerPanZoomStart,
+      onPointerPanZoomUpdate: logic.onPointerPanZoomUpdate,
+      onPointerPanZoomEnd: logic.onPointerPanZoomEnd,
+      child: PhotoViewGallery.builder(
       itemCount: 1,
       builder: (_, __) => PhotoViewGalleryPageOptions.customChild(
         controller: state.photoViewController,
@@ -51,6 +57,7 @@ class HorizontalListLayout extends BaseLayout {
             separatorBuilder: (_, __) => Obx(() => SizedBox(width: readSetting.imageSpace.value.toDouble())),
           ),
         ),
+      ),
       ),
     );
   }

--- a/lib/src/pages/read/layout/horizontal_list/horizontal_list_layout.dart
+++ b/lib/src/pages/read/layout/horizontal_list/horizontal_list_layout.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:jhentai/src/pages/read/layout/horizontal_list/horizontal_list_layout_state.dart';
+import 'package:jhentai/src/config/ui_config.dart';
 import 'package:jhentai/src/widget/eh_wheel_scroll_listener.dart';
 import 'package:photo_view/photo_view_gallery.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
@@ -35,7 +36,7 @@ class HorizontalListLayout extends BaseLayout {
         controller: state.photoViewController,
         initialScale: 1.0,
         minScale: 1.0,
-        maxScale: 2.5,
+        maxScale: UIConfig.readPageMaxScale,
         scaleStateCycle: readSetting.enableDoubleTapToScaleUp.isTrue ? logic.scaleStateCycle : null,
         enableTapDragZoom: readSetting.enableTapDragToScaleUp.isTrue,
         child: EHWheelSpeedControllerForReadPage(

--- a/lib/src/pages/read/layout/horizontal_list/horizontal_list_layout_logic.dart
+++ b/lib/src/pages/read/layout/horizontal_list/horizontal_list_layout_logic.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:collection/collection.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
+import 'package:photo_view/photo_view.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 import '../../../../setting/read_setting.dart';
@@ -13,6 +14,9 @@ import 'horizontal_list_layout_state.dart';
 
 class HorizontalListLayoutLogic extends BaseLayoutLogic {
   HorizontalListLayoutState state = HorizontalListLayoutState();
+  
+  @override
+  PhotoViewController get photoViewController => state.photoViewController;
 
   @override
   void onInit() {

--- a/lib/src/pages/read/layout/horizontal_page/horizontal_page_layout.dart
+++ b/lib/src/pages/read/layout/horizontal_page/horizontal_page_layout.dart
@@ -21,29 +21,41 @@ class HorizontalPageLayout extends BaseLayout {
   Widget buildBody(BuildContext context) {
     return EHWheelListener(
       onPointerScroll: readSetting.isInFitWidthReadDirection ? null : logic.onPointerScroll,
+      onPointerPanZoomStart: logic.onPointerPanZoomStart,
+      onPointerPanZoomUpdate: logic.onPointerPanZoomUpdate,
+      onPointerPanZoomEnd: logic.onPointerPanZoomEnd,
       child: PhotoViewGallery.builder(
-        itemCount: readPageState.readPageInfo.pageCount,
-        scrollPhysics: const ClampingScrollPhysics(),
-        pageController: logic.pageController,
-        cacheExtent: readPageState.readPageInfo.mode == ReadMode.online
-            ? readSetting.preloadPageCount.value.toDouble()
-            : readSetting.preloadPageCountLocal.value.toDouble(),
-        reverse: readSetting.isInRight2LeftDirection,
+        itemCount: 1,
         builder: (context, index) => PhotoViewGalleryPageOptions.customChild(
+          controller: state.photoViewController,
           initialScale: 1.0,
           minScale: 1.0,
           maxScale: 2.5,
-          scaleStateCycle: readSetting.enableDoubleTapToScaleUp.isTrue ? logic.scaleStateCycle : null,
-          enableTapDragZoom: readSetting.enableTapDragToScaleUp.isTrue,
-          child: Obx(() {
-            Widget item = readPageState.readPageInfo.mode == ReadMode.online ? buildItemInOnlineMode(context, index) : buildItemInLocalMode(context, index);
+          child: PhotoViewGallery.builder(
+            itemCount: readPageState.readPageInfo.pageCount,
+            scrollPhysics: const ClampingScrollPhysics(),
+            pageController: logic.pageController,
+            cacheExtent: readPageState.readPageInfo.mode == ReadMode.online
+                ? readSetting.preloadPageCount.value.toDouble()
+                : readSetting.preloadPageCountLocal.value.toDouble(),
+            reverse: readSetting.isInRight2LeftDirection,
+            builder: (context, index) => PhotoViewGalleryPageOptions.customChild(
+              initialScale: 1.0,
+              minScale: 1.0,
+              maxScale: 2.5,
+              scaleStateCycle: readSetting.enableDoubleTapToScaleUp.isTrue ? logic.scaleStateCycle : null,
+              enableTapDragZoom: readSetting.enableTapDragToScaleUp.isTrue,
+              child: Obx(() {
+                Widget item = readPageState.readPageInfo.mode == ReadMode.online ? buildItemInOnlineMode(context, index) : buildItemInLocalMode(context, index);
 
-            if (readSetting.isInFitWidthReadDirection) {
-              item = Center(child: SingleChildScrollView(controller: ScrollController(), child: item));
-            }
+                if (readSetting.isInFitWidthReadDirection) {
+                  item = Center(child: SingleChildScrollView(controller: ScrollController(), child: item));
+                }
 
-            return item;
-          }),
+                return item;
+              }),
+            ),
+          ),
         ),
       ),
     );

--- a/lib/src/pages/read/layout/horizontal_page/horizontal_page_layout.dart
+++ b/lib/src/pages/read/layout/horizontal_page/horizontal_page_layout.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:jhentai/src/model/read_page_info.dart';
+import 'package:jhentai/src/config/ui_config.dart';
 import 'package:jhentai/src/widget/eh_wheel_scroll_listener.dart';
 import 'package:photo_view/photo_view_gallery.dart';
 
@@ -30,7 +31,7 @@ class HorizontalPageLayout extends BaseLayout {
           controller: state.photoViewController,
           initialScale: 1.0,
           minScale: 1.0,
-          maxScale: 2.5,
+          maxScale: UIConfig.readPageMaxScale,
           child: PhotoViewGallery.builder(
             itemCount: readPageState.readPageInfo.pageCount,
             scrollPhysics: const ClampingScrollPhysics(),
@@ -42,7 +43,7 @@ class HorizontalPageLayout extends BaseLayout {
             builder: (context, index) => PhotoViewGalleryPageOptions.customChild(
               initialScale: 1.0,
               minScale: 1.0,
-              maxScale: 2.5,
+              maxScale: UIConfig.readPageMaxScale,
               scaleStateCycle: readSetting.enableDoubleTapToScaleUp.isTrue ? logic.scaleStateCycle : null,
               enableTapDragZoom: readSetting.enableTapDragToScaleUp.isTrue,
               child: Obx(() {

--- a/lib/src/pages/read/layout/horizontal_page/horizontal_page_layout_logic.dart
+++ b/lib/src/pages/read/layout/horizontal_page/horizontal_page_layout_logic.dart
@@ -4,12 +4,16 @@ import 'dart:math';
 import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
 import 'package:jhentai/src/setting/read_setting.dart';
+import 'package:photo_view/photo_view.dart';
 
 import '../base/base_layout_logic.dart';
 import 'horizontal_page_layout_state.dart';
 
 class HorizontalPageLayoutLogic extends BaseLayoutLogic {
   HorizontalPageLayoutState state = HorizontalPageLayoutState();
+
+  @override
+  PhotoViewController get photoViewController => state.photoViewController;
 
   late PageController pageController;
 

--- a/lib/src/pages/read/layout/horizontal_page/horizontal_page_layout_state.dart
+++ b/lib/src/pages/read/layout/horizontal_page/horizontal_page_layout_state.dart
@@ -1,1 +1,5 @@
-class HorizontalPageLayoutState {}
+import 'package:photo_view/photo_view.dart';
+
+class HorizontalPageLayoutState {
+  final PhotoViewController photoViewController = PhotoViewController();
+}

--- a/lib/src/pages/read/layout/vertical_list/vertical_list_layout.dart
+++ b/lib/src/pages/read/layout/vertical_list/vertical_list_layout.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:jhentai/src/model/read_page_info.dart';
 import 'package:jhentai/src/pages/read/layout/vertical_list/vertical_list_layout_state.dart';
+import 'package:jhentai/src/config/ui_config.dart';
 import 'package:jhentai/src/widget/eh_wheel_scroll_listener.dart';
 import 'package:photo_view/photo_view_gallery.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
@@ -35,7 +36,7 @@ class VerticalListLayout extends BaseLayout {
             controller: state.photoViewController,
             initialScale: 1.0,
             minScale: 1.0,
-            maxScale: 2.5,
+            maxScale: UIConfig.readPageMaxScale,
             scaleStateCycle: readSetting.enableDoubleTapToScaleUp.isTrue ? logic.scaleStateCycle : null,
             enableTapDragZoom: readSetting.enableTapDragToScaleUp.isTrue,
             child: EHWheelSpeedControllerForReadPage(

--- a/lib/src/pages/read/layout/vertical_list/vertical_list_layout.dart
+++ b/lib/src/pages/read/layout/vertical_list/vertical_list_layout.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:jhentai/src/model/read_page_info.dart';
 import 'package:jhentai/src/pages/read/layout/vertical_list/vertical_list_layout_state.dart';
+import 'package:jhentai/src/widget/eh_wheel_scroll_listener.dart';
 import 'package:photo_view/photo_view_gallery.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
-import 'package:zoom_view/zoom_view.dart';
 
 import '../../../../setting/read_setting.dart';
 import '../../../../utils/screen_size_util.dart';
@@ -21,32 +21,38 @@ class VerticalListLayout extends BaseLayout {
 
   @override
   Widget buildBody(BuildContext context) {
-    return GetBuilder<VerticalListLayoutLogic>(
-      id: logic.verticalLayoutId,
-      builder: (_) => PhotoViewGallery.builder(
-        scrollDirection: Axis.vertical,
-        itemCount: 1,
-        builder: (_, __) => PhotoViewGalleryPageOptions.customChild(
-          controller: state.photoViewController,
-          initialScale: 1.0,
-          minScale: 1.0,
-          maxScale: 2.5,
-          scaleStateCycle: readSetting.enableDoubleTapToScaleUp.isTrue ? logic.scaleStateCycle : null,
-          enableTapDragZoom: readSetting.enableTapDragToScaleUp.isTrue,
-          child: EHWheelSpeedControllerForReadPage(
-            scrollOffsetController: state.scrollOffsetController,
-            child: ScrollablePositionedList.separated(
-              physics: const ClampingScrollPhysics(),
-              minCacheExtent: readPageState.readPageInfo.mode == ReadMode.online
-                  ? readSetting.preloadDistance * screenHeight * 1
-                  : readSetting.preloadDistanceLocal * screenHeight * 1,
-              initialScrollIndex: readPageState.readPageInfo.initialIndex,
-              itemCount: readPageState.readPageInfo.pageCount,
-              itemScrollController: state.itemScrollController,
-              itemPositionsListener: state.itemPositionsListener,
+    return EHWheelListener(
+      onPointerScroll: logic.onPointerScroll,
+      onPointerPanZoomStart: logic.onPointerPanZoomStart,
+      onPointerPanZoomUpdate: logic.onPointerPanZoomUpdate,
+      onPointerPanZoomEnd: logic.onPointerPanZoomEnd,
+      child: GetBuilder<VerticalListLayoutLogic>(
+        id: logic.verticalLayoutId,
+        builder: (_) => PhotoViewGallery.builder(
+          scrollDirection: Axis.vertical,
+          itemCount: 1,
+          builder: (_, __) => PhotoViewGalleryPageOptions.customChild(
+            controller: state.photoViewController,
+            initialScale: 1.0,
+            minScale: 1.0,
+            maxScale: 2.5,
+            scaleStateCycle: readSetting.enableDoubleTapToScaleUp.isTrue ? logic.scaleStateCycle : null,
+            enableTapDragZoom: readSetting.enableTapDragToScaleUp.isTrue,
+            child: EHWheelSpeedControllerForReadPage(
               scrollOffsetController: state.scrollOffsetController,
-              itemBuilder: _imageBuilder,
-              separatorBuilder: (_, __) => Obx(() => SizedBox(height: readSetting.imageSpace.value.toDouble())),
+              child: ScrollablePositionedList.separated(
+                physics: const ClampingScrollPhysics(),
+                minCacheExtent: readPageState.readPageInfo.mode == ReadMode.online
+                    ? readSetting.preloadDistance * screenHeight * 1
+                    : readSetting.preloadDistanceLocal * screenHeight * 1,
+                initialScrollIndex: readPageState.readPageInfo.initialIndex,
+                itemCount: readPageState.readPageInfo.pageCount,
+                itemScrollController: state.itemScrollController,
+                itemPositionsListener: state.itemPositionsListener,
+                scrollOffsetController: state.scrollOffsetController,
+                itemBuilder: _imageBuilder,
+                separatorBuilder: (_, __) => Obx(() => SizedBox(height: readSetting.imageSpace.value.toDouble())),
+              ),
             ),
           ),
         ),

--- a/lib/src/pages/read/layout/vertical_list/vertical_list_layout_logic.dart
+++ b/lib/src/pages/read/layout/vertical_list/vertical_list_layout_logic.dart
@@ -6,6 +6,7 @@ import 'package:flutter/widgets.dart';
 import 'package:get/get.dart';
 import 'package:jhentai/src/extension/get_logic_extension.dart';
 import 'package:jhentai/src/pages/read/layout/vertical_list/vertical_list_layout_state.dart';
+import 'package:photo_view/photo_view.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 import '../../../../setting/read_setting.dart';
@@ -16,6 +17,9 @@ class VerticalListLayoutLogic extends BaseLayoutLogic {
   final String verticalLayoutId = 'verticalLayoutId';
 
   VerticalListLayoutState state = VerticalListLayoutState();
+  
+  @override
+  PhotoViewController get photoViewController => state.photoViewController;
 
   late Worker imageRegionWidthRatioListener;
 

--- a/lib/src/widget/eh_wheel_scroll_listener.dart
+++ b/lib/src/widget/eh_wheel_scroll_listener.dart
@@ -4,8 +4,18 @@ import 'package:flutter/material.dart';
 class EHWheelListener extends StatelessWidget {
   final Widget child;
   final ValueChanged<PointerScrollEvent>? onPointerScroll;
+  final ValueChanged<PointerPanZoomStartEvent>? onPointerPanZoomStart;
+  final ValueChanged<PointerPanZoomUpdateEvent>? onPointerPanZoomUpdate;
+  final ValueChanged<PointerPanZoomEndEvent>? onPointerPanZoomEnd;
 
-  const EHWheelListener({Key? key, required this.child, this.onPointerScroll}) : super(key: key);
+  const EHWheelListener({
+    Key? key,
+    required this.child,
+    this.onPointerScroll,
+    this.onPointerPanZoomStart,
+    this.onPointerPanZoomUpdate,
+    this.onPointerPanZoomEnd,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -15,6 +25,9 @@ class EHWheelListener extends StatelessWidget {
           onPointerScroll?.call(event);
         }
       },
+      onPointerPanZoomStart: onPointerPanZoomStart,
+      onPointerPanZoomUpdate: onPointerPanZoomUpdate,
+      onPointerPanZoomEnd: onPointerPanZoomEnd,
       child: child,
     );
   }


### PR DESCRIPTION
# Feature

## 2-finger touchpad gesture zoom

- Able to freely zoom in/out with 2-finger touchpad gesture
- Works in all Reading Direction
  - Continuous mode has the best experience: able to zoom in to all corners of the page
  - In other Reading Direction, sometime unable to zoom to corner area of a page (because reader will just move to the next/prev page after pulling to a certain extent)

## Ctrl+mouse wheel zoom

- Seems to only works in "LTR/RTL + Single Page/Double Columns" Reading Direction mode
- Ctrl + Mouse wheel up to zoom in, Ctrl + Mouse wheel down to zoom out

# Testing

- Only tested on Windows 10
- Touchpad gesture zoom: https://streamable.com/mdchtg
- Mouse wheel zoom: https://streamable.com/q3c5a7

# Disclaimer

- Most of the code are written by Antigravity (Gemini), I practically has no experience with Flutter