### PR TITLE
Fix(android): avoid startup crash on Android 16 storage restrictions

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -47,7 +47,7 @@ android {
 
     defaultConfig {
         applicationId "top.jtmonster.jhentai"
-        minSdkVersion 21
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/lib/src/database/database.dart
+++ b/lib/src/database/database.dart
@@ -268,7 +268,20 @@ class AppDb extends _$AppDb {
 
   /// copy files
   Future<void> _updateConfigFileLocation() async {
-    await pathService.appSupportDir?.copy(pathService.getVisibleDir().path);
+    Directory? targetDir = pathService.appSupportDir ?? pathService.appDocDir;
+    Directory? sourceDir = pathService.externalStorageDir;
+    if (targetDir == null || sourceDir == null || targetDir.path == sourceDir.path) {
+      return;
+    }
+
+    try {
+      await targetDir.create(recursive: true);
+      if (await sourceDir.exists()) {
+        await sourceDir.copy(targetDir.path);
+      }
+    } catch (e) {
+      log.warning('Skip config file location migration due to file access error', e);
+    }
   }
 
   Future<void> _deleteImageSizeColumn(Migrator m) async {
@@ -384,7 +397,14 @@ class AppDb extends _$AppDb {
 
 LazyDatabase _openConnection() {
   return LazyDatabase(() async {
-    final file = io.File(join(pathService.getVisibleDir().path, 'db.sqlite'));
+    io.File file;
+    try {
+      file = await _resolveDatabaseFile();
+    } catch (e, s) {
+      log.error('Resolve database file failed, fallback to temp dir', e, s);
+      file = io.File(join(pathService.tempDir.path, 'db_fallback.sqlite'));
+      await file.parent.create(recursive: true);
+    }
 
     if (Platform.isAndroid) {
       await applyWorkaroundToOpenSqlite3OnOldAndroidVersions();
@@ -392,8 +412,78 @@ LazyDatabase _openConnection() {
 
     sqlite3.tempDirectory = pathService.tempDir.path;
 
-    return NativeDatabase(file);
+    try {
+      return NativeDatabase(file);
+    } catch (e, s) {
+      log.error('Open database failed, fallback to temp database', e, s);
+      final fallbackFile = io.File(join(pathService.tempDir.path, 'db_fallback.sqlite'));
+      await fallbackFile.parent.create(recursive: true);
+      return NativeDatabase(fallbackFile);
+    }
   });
+}
+
+Future<io.File> _resolveDatabaseFile() async {
+  final io.Directory baseDir = pathService.appSupportDir ?? pathService.appDocDir ?? pathService.tempDir;
+  io.Directory dbDir = io.Directory(join(baseDir.path, 'db'));
+
+  try {
+    await dbDir.create(recursive: true);
+  } catch (e, s) {
+    log.warning('Create db directory failed, fallback to temp dir', e);
+    log.uploadError(e, stackTrace: s);
+    dbDir = pathService.tempDir;
+    await dbDir.create(recursive: true);
+  }
+
+  final io.File newDbFile = io.File(join(dbDir.path, 'db.sqlite'));
+  await _migrateLegacyDbFileIfNeeded(newDbFile);
+  return newDbFile;
+}
+
+Future<void> _migrateLegacyDbFileIfNeeded(io.File targetDbFile) async {
+  try {
+    if (await targetDbFile.exists()) {
+      return;
+    }
+
+    final Set<String> legacyDirPaths = {
+      if (pathService.externalStorageDir != null) pathService.externalStorageDir!.path,
+      if (pathService.appDocDir != null) pathService.appDocDir!.path,
+    };
+
+    for (final String legacyDirPath in legacyDirPaths) {
+      final io.File legacyDbFile = io.File(join(legacyDirPath, 'db.sqlite'));
+      if (legacyDbFile.path == targetDbFile.path) {
+        continue;
+      }
+
+      try {
+        if (!await legacyDbFile.exists()) {
+          continue;
+        }
+
+        await targetDbFile.parent.create(recursive: true);
+        await legacyDbFile.copy(targetDbFile.path);
+
+        final io.File legacyWalFile = io.File('${legacyDbFile.path}-wal');
+        final io.File legacyShmFile = io.File('${legacyDbFile.path}-shm');
+        if (await legacyWalFile.exists()) {
+          await legacyWalFile.copy('${targetDbFile.path}-wal');
+        }
+        if (await legacyShmFile.exists()) {
+          await legacyShmFile.copy('${targetDbFile.path}-shm');
+        }
+        return;
+      } catch (e, s) {
+        log.warning('Migrate legacy database failed, continue startup', e);
+        log.uploadError(e, stackTrace: s);
+      }
+    }
+  } catch (e, s) {
+    log.warning('Scan legacy database failed, continue startup', e);
+    log.uploadError(e, stackTrace: s);
+  }
 }
 
 AppDb appDb = AppDb();

--- a/lib/src/database/database.dart
+++ b/lib/src/database/database.dart
@@ -268,6 +268,10 @@ class AppDb extends _$AppDb {
 
   /// copy files
   Future<void> _updateConfigFileLocation() async {
+    if (pathService.isAndroid16OrAbove) {
+      return;
+    }
+
     Directory? targetDir = pathService.appSupportDir ?? pathService.appDocDir;
     Directory? sourceDir = pathService.externalStorageDir;
     if (targetDir == null || sourceDir == null || targetDir.path == sourceDir.path) {
@@ -424,7 +428,9 @@ LazyDatabase _openConnection() {
 }
 
 Future<io.File> _resolveDatabaseFile() async {
-  final io.Directory baseDir = pathService.appSupportDir ?? pathService.appDocDir ?? pathService.tempDir;
+  final io.Directory baseDir = pathService.isAndroid16OrAbove
+      ? pathService.getInternalRootDir()
+      : (pathService.appSupportDir ?? pathService.appDocDir ?? pathService.tempDir);
   io.Directory dbDir = io.Directory(join(baseDir.path, 'db'));
 
   try {
@@ -442,6 +448,10 @@ Future<io.File> _resolveDatabaseFile() async {
 }
 
 Future<void> _migrateLegacyDbFileIfNeeded(io.File targetDbFile) async {
+  if (pathService.isAndroid16OrAbove) {
+    return;
+  }
+
   try {
     if (await targetDbFile.exists()) {
       return;

--- a/lib/src/enum/config_enum.dart
+++ b/lib/src/enum/config_enum.dart
@@ -1,6 +1,7 @@
 enum ConfigEnum {
   /// app update
   firstOpenInited('firstOpenInited'),
+  android16ModeShown('android16ModeShown'),
   renameDownloadMetadata('renameDownloadMetadata'),
   migrateGalleryHistory('migrateGalleryHistory'),
   migrateStorageConfig('migrateStorageConfig'),

--- a/lib/src/pages/home_page.dart
+++ b/lib/src/pages/home_page.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:clipboard/clipboard.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:jhentai/src/enum/config_enum.dart';
 import 'package:jhentai/src/model/gallery_image_page_url.dart';
 import 'package:jhentai/src/model/gallery_url.dart';
 import 'package:jhentai/src/pages/details/details_page_logic.dart';
@@ -12,7 +13,9 @@ import 'package:jhentai/src/pages/layout/mobile_v2/mobile_layout_page_v2.dart';
 import 'package:jhentai/src/pages/layout/tablet_v2/tablet_layout_page_v2.dart';
 import 'package:jhentai/src/setting/style_setting.dart';
 import 'package:jhentai/src/setting/user_setting.dart';
+import 'package:jhentai/src/service/local_config_service.dart';
 import 'package:jhentai/src/service/log.dart';
+import 'package:jhentai/src/service/path_service.dart';
 import 'package:jhentai/src/utils/toast_util.dart';
 import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 import 'package:window_manager/window_manager.dart';
@@ -53,6 +56,7 @@ class _HomePageState extends State<HomePage> with LoginRequiredMixin, WindowList
   void initState() {
     super.initState();
     initToast(context);
+    _showAndroid16StorageNoticeIfNeeded();
     _initSharingIntent();
     _handleUrlInClipBoard();
 
@@ -95,6 +99,28 @@ class _HomePageState extends State<HomePage> with LoginRequiredMixin, WindowList
         ),
       ),
     );
+  }
+
+  void _showAndroid16StorageNoticeIfNeeded() {
+    if (!pathService.isAndroid16OrAbove) {
+      return;
+    }
+
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final String? shown = await localConfigService.read(configKey: ConfigEnum.android16ModeShown);
+      if (shown == 'true') {
+        return;
+      }
+
+      snack(
+        'Android 16 Storage Notice',
+        'Android 16 tightened storage access. JHenTai now uses internal app storage. If old data is in '
+            '/storage/emulated/0/Android/data/top.jtmonster.jhentai/files, migrate/import it manually.',
+        isShort: false,
+      );
+
+      await localConfigService.write(configKey: ConfigEnum.android16ModeShown, value: 'true');
+    });
   }
 
   /// Listen to share or open urls/text coming from outside the app while the app is in the memory or is closed

--- a/lib/src/service/app_update_service.dart
+++ b/lib/src/service/app_update_service.dart
@@ -47,7 +47,7 @@ import '../utils/uuid_util.dart';
 AppUpdateService appUpdateService = AppUpdateService();
 
 class AppUpdateService with JHLifeCircleBeanErrorCatch implements JHLifeCircleBean {
-  late File file;
+  File? file;
   int? fromVersion;
   static const int toVersion = 12;
 
@@ -68,13 +68,46 @@ class AppUpdateService with JHLifeCircleBeanErrorCatch implements JHLifeCircleBe
   @override
   List<JHLifeCircleBean> get initDependencies => super.initDependencies..addAll(updateHandlers.map((h) => h.initDependencies).expand((e) => e));
 
+  Directory? _resolveVersionDir() {
+    return pathService.appSupportDir ?? pathService.appDocDir ?? pathService.externalStorageDir;
+  }
+
+  Future<void> _migrateLegacyVersionFile(File targetFile) async {
+    try {
+      File oldFile = File(join(pathService.getVisibleDir().path, 'jhentai.version'));
+      if (oldFile.path == targetFile.path) {
+        return;
+      }
+
+      if (await oldFile.exists() && !await targetFile.exists()) {
+        await targetFile.parent.create(recursive: true);
+        await oldFile.copy(targetFile.path);
+      }
+    } catch (e, s) {
+      log.error('Migrate legacy jhentai.version failed', e, s);
+    }
+  }
+
   @override
   Future<void> doInitBean() async {
-    file = File(join(pathService.getVisibleDir().path, 'jhentai.version'));
-    if (file.existsSync()) {
-      fromVersion = int.tryParse(await file.readAsString());
+    Directory? versionDir = _resolveVersionDir();
+    if (versionDir == null) {
+      log.warning('AppUpdateService cannot resolve version directory, use in-memory version only.');
     } else {
-      file.create().then((_) => file.writeAsString(toVersion.toString()));
+      try {
+        await versionDir.create(recursive: true);
+        file = File(join(versionDir.path, 'jhentai.version'));
+        await _migrateLegacyVersionFile(file!);
+
+        if (await file!.exists()) {
+          fromVersion = int.tryParse(await file!.readAsString());
+        } else {
+          await file!.parent.create(recursive: true);
+          await file!.writeAsString(toVersion.toString());
+        }
+      } catch (e, s) {
+        log.error('Init jhentai.version failed, continue with defaults', e, s);
+      }
     }
 
     log.debug('AppUpdateService fromVersion: $fromVersion, toVersion: $toVersion');
@@ -105,7 +138,16 @@ class AppUpdateService with JHLifeCircleBeanErrorCatch implements JHLifeCircleBe
 
     await Future.wait(futures);
 
-    await file.writeAsString(toVersion.toString());
+    if (file == null) {
+      return;
+    }
+
+    try {
+      await file!.parent.create(recursive: true);
+      await file!.writeAsString(toVersion.toString());
+    } catch (e, s) {
+      log.error('Persist jhentai.version failed', e, s);
+    }
   }
 }
 

--- a/lib/src/service/app_update_service.dart
+++ b/lib/src/service/app_update_service.dart
@@ -69,10 +69,18 @@ class AppUpdateService with JHLifeCircleBeanErrorCatch implements JHLifeCircleBe
   List<JHLifeCircleBean> get initDependencies => super.initDependencies..addAll(updateHandlers.map((h) => h.initDependencies).expand((e) => e));
 
   Directory? _resolveVersionDir() {
+    if (pathService.isAndroid16OrAbove) {
+      return pathService.getInternalRootDir();
+    }
+
     return pathService.appSupportDir ?? pathService.appDocDir ?? pathService.externalStorageDir;
   }
 
   Future<void> _migrateLegacyVersionFile(File targetFile) async {
+    if (pathService.isAndroid16OrAbove) {
+      return;
+    }
+
     try {
       File oldFile = File(join(pathService.getVisibleDir().path, 'jhentai.version'));
       if (oldFile.path == targetFile.path) {

--- a/lib/src/service/local_config_service.dart
+++ b/lib/src/service/local_config_service.dart
@@ -47,51 +47,71 @@ class LocalConfigService with JHLifeCircleBeanErrorCatch implements JHLifeCircle
   @override
   Future<void> doAfterBeanReady() async {}
 
-  Future<int> write({required ConfigEnum configKey, String subConfigKey = defaultSubConfigKey, required String value}) {
-    return appDb.managers.localConfig.create(
-      (l) => l(configKey: configKey.key, subConfigKey: subConfigKey, value: value, utime: DateTime.now().toString()),
-      mode: InsertMode.insertOrReplace,
-    );
+  Future<int> write({required ConfigEnum configKey, String subConfigKey = defaultSubConfigKey, required String value}) async {
+    try {
+      return await appDb.managers.localConfig.create(
+        (l) => l(configKey: configKey.key, subConfigKey: subConfigKey, value: value, utime: DateTime.now().toString()),
+        mode: InsertMode.insertOrReplace,
+      );
+    } catch (_) {
+      return 0;
+    }
   }
 
   Future<void> batchWrite(List<LocalConfigCompanion> localConfigs) async {
-    return appDb.managers.localConfig.bulkCreate(
-      (l) => localConfigs
-          .map((i) => l(
-                configKey: i.configKey.value,
-                subConfigKey: i.subConfigKey.value,
-                value: i.value.value,
-                utime: DateTime.now().toString(),
-              ))
-          .toList(),
-      mode: InsertMode.insertOrReplace,
-    );
+    try {
+      await appDb.managers.localConfig.bulkCreate(
+        (l) => localConfigs
+            .map((i) => l(
+                  configKey: i.configKey.value,
+                  subConfigKey: i.subConfigKey.value,
+                  value: i.value.value,
+                  utime: DateTime.now().toString(),
+                ))
+            .toList(),
+        mode: InsertMode.insertOrReplace,
+      );
+    } catch (_) {
+      return;
+    }
   }
 
-  Future<String?> read({required ConfigEnum configKey, String subConfigKey = defaultSubConfigKey}) {
-    return appDb.managers.localConfig
-        .filter((config) => config.configKey.equals(configKey.key) & config.subConfigKey.equals(subConfigKey))
-        .getSingleOrNull()
-        .then((value) => value?.value);
+  Future<String?> read({required ConfigEnum configKey, String subConfigKey = defaultSubConfigKey}) async {
+    try {
+      return await appDb.managers.localConfig
+          .filter((config) => config.configKey.equals(configKey.key) & config.subConfigKey.equals(subConfigKey))
+          .getSingleOrNull()
+          .then((value) => value?.value);
+    } catch (_) {
+      return null;
+    }
   }
 
-  Future<List<LocalConfig>> readWithAllSubKeys({required ConfigEnum configKey}) {
-    return appDb.managers.localConfig.filter((config) => config.configKey.equals(configKey.key)).get().then((value) {
-      return value
-          .map((e) => LocalConfig(
-                configKey: ConfigEnum.from(e.configKey),
-                subConfigKey: e.subConfigKey,
-                value: e.value,
-                utime: e.utime,
-              ))
-          .toList();
-    });
+  Future<List<LocalConfig>> readWithAllSubKeys({required ConfigEnum configKey}) async {
+    try {
+      return await appDb.managers.localConfig.filter((config) => config.configKey.equals(configKey.key)).get().then((value) {
+        return value
+            .map((e) => LocalConfig(
+                  configKey: ConfigEnum.from(e.configKey),
+                  subConfigKey: e.subConfigKey,
+                  value: e.value,
+                  utime: e.utime,
+                ))
+            .toList();
+      });
+    } catch (_) {
+      return [];
+    }
   }
 
-  Future<bool> delete({required ConfigEnum configKey, String subConfigKey = defaultSubConfigKey}) {
-    return appDb.managers.localConfig
-        .filter((config) => config.configKey.equals(configKey.key) & config.subConfigKey.equals(subConfigKey))
-        .delete()
-        .then((value) => value > 0);
+  Future<bool> delete({required ConfigEnum configKey, String subConfigKey = defaultSubConfigKey}) async {
+    try {
+      return await appDb.managers.localConfig
+          .filter((config) => config.configKey.equals(configKey.key) & config.subConfigKey.equals(subConfigKey))
+          .delete()
+          .then((value) => value > 0);
+    } catch (_) {
+      return false;
+    }
   }
 }

--- a/lib/src/service/local_gallery_service.dart
+++ b/lib/src/service/local_gallery_service.dart
@@ -108,10 +108,17 @@ class LocalGalleryService extends GetxController with GridBasePageServiceMixin, 
   }
 
   Future<void> _loadGalleriesFromDisk() {
-    List<Future> futures = downloadSetting.extraGalleryScanPath.map((path) => _parseDirectory(Directory(path), true)).toList();
+    final List<String> scanPaths = pathService.isAndroid16OrAbove
+        ? downloadSetting.extraGalleryScanPath.where((path) => !pathService.isRestrictedAndroidDataPath(path)).toList()
+        : downloadSetting.extraGalleryScanPath.toList();
+    if (pathService.isAndroid16OrAbove && scanPaths.length != downloadSetting.extraGalleryScanPath.length) {
+      log.warning('Skip restricted local gallery scan path on Android 16+: ${downloadSetting.extraGalleryScanPath}');
+    }
+
+    List<Future> futures = scanPaths.map((path) => _parseDirectory(Directory(path), true)).toList();
 
     return Future.wait(futures).onError((error, stackTrace) {
-      log.error('_loadGalleriesFromDisk failed, path: ${downloadSetting.extraGalleryScanPath}', error, stackTrace);
+      log.error('_loadGalleriesFromDisk failed, path: $scanPaths', error, stackTrace);
       return [];
     }).whenComplete(() {
       allGallerys.sort((a, b) => FileUtil.naturalCompare(a.title, b.title));

--- a/lib/src/service/log.dart
+++ b/lib/src/service/log.dart
@@ -180,7 +180,9 @@ class LogService with JHLifeCircleBeanErrorCatch implements JHLifeCircleBean {
       return;
     }
 
-    final Directory? baseDir = pathService.appSupportDir ?? pathService.appDocDir ?? pathService.externalStorageDir;
+    final Directory? baseDir = pathService.isAndroid16OrAbove
+        ? pathService.getInternalRootDir()
+        : (pathService.appSupportDir ?? pathService.appDocDir ?? pathService.externalStorageDir);
     if (baseDir == null) {
       _disableFileLogging = true;
       _fallbackConsole('Init log dir failed: no available base directory, fallback to console logging.');

--- a/lib/src/service/log.dart
+++ b/lib/src/service/log.dart
@@ -19,6 +19,7 @@ LogService log = LogService();
 
 class LogService with JHLifeCircleBeanErrorCatch implements JHLifeCircleBean {
   String? logDirPath;
+  bool _disableFileLogging = false;
 
   Logger? _consoleLogger;
   Logger? _verboseFileLogger;
@@ -57,51 +58,94 @@ class LogService with JHLifeCircleBeanErrorCatch implements JHLifeCircleBean {
   Future<void> doAfterBeanReady() async {}
 
   /// For actions that print params
-  void trace(Object msg, [bool withStack = false]) async {
-    await _initLogger();
-    _consoleLogger?.t(msg, stackTrace: withStack ? null : StackTrace.empty);
-    _verboseFileLogger?.t(msg, stackTrace: withStack ? null : StackTrace.empty);
+  void trace(Object msg, [bool withStack = false]) {
+    _safeLogCall(() async {
+      await _initLogger();
+      _consoleLogger?.t(msg, stackTrace: withStack ? null : StackTrace.empty);
+      _verboseFileLogger?.t(msg, stackTrace: withStack ? null : StackTrace.empty);
+    });
   }
 
   /// For actions that is invisible to user
-  void debug(Object msg, [bool withStack = false]) async {
-    await _initLogger();
-    _consoleLogger?.d(msg, stackTrace: withStack ? null : StackTrace.empty);
-    _verboseFileLogger?.d(msg, stackTrace: withStack ? null : StackTrace.empty);
+  void debug(Object msg, [bool withStack = false]) {
+    _safeLogCall(() async {
+      await _initLogger();
+      _consoleLogger?.d(msg, stackTrace: withStack ? null : StackTrace.empty);
+      _verboseFileLogger?.d(msg, stackTrace: withStack ? null : StackTrace.empty);
+    });
   }
 
   /// For actions that is visible to user
-  void info(Object msg, [bool withStack = false]) async {
-    await _initLogger();
-    _consoleLogger?.i(msg, stackTrace: withStack ? null : StackTrace.empty);
-    _verboseFileLogger?.i(msg, stackTrace: withStack ? null : StackTrace.empty);
+  void info(Object msg, [bool withStack = false]) {
+    _safeLogCall(() async {
+      await _initLogger();
+      _consoleLogger?.i(msg, stackTrace: withStack ? null : StackTrace.empty);
+      _verboseFileLogger?.i(msg, stackTrace: withStack ? null : StackTrace.empty);
+    });
   }
 
-  void warning(Object msg, [Object? error, bool withStack = false]) async {
-    await _initLogger();
-    _consoleLogger?.w(msg, error: error, stackTrace: withStack ? null : StackTrace.empty);
-    _verboseFileLogger?.w(msg, error: error, stackTrace: withStack ? null : StackTrace.empty);
-    _warningFileLogger?.w(msg, error: error, stackTrace: withStack ? null : StackTrace.empty);
+  void warning(Object msg, [Object? error, bool withStack = false]) {
+    _safeLogCall(() async {
+      await _initLogger();
+      _consoleLogger?.w(msg, error: error, stackTrace: withStack ? null : StackTrace.empty);
+      _verboseFileLogger?.w(msg, error: error, stackTrace: withStack ? null : StackTrace.empty);
+      _warningFileLogger?.w(msg, error: error, stackTrace: withStack ? null : StackTrace.empty);
+    });
   }
 
-  void error(Object msg, [Object? error, StackTrace? stackTrace]) async {
-    await _initLogger();
-    _consoleLogger?.e(msg, error: error, stackTrace: stackTrace);
-    _verboseFileLogger?.e(msg, error: error, stackTrace: stackTrace);
-    _warningFileLogger?.e(msg, error: error, stackTrace: stackTrace);
+  void error(Object msg, [Object? error, StackTrace? stackTrace]) {
+    _safeLogCall(() async {
+      await _initLogger();
+      _consoleLogger?.e(msg, error: error, stackTrace: stackTrace);
+      _verboseFileLogger?.e(msg, error: error, stackTrace: stackTrace);
+      _warningFileLogger?.e(msg, error: error, stackTrace: stackTrace);
+    });
   }
 
-  void download(Object msg) async {
-    await _initLogger();
-    _consoleLogger?.t(msg, stackTrace: StackTrace.empty);
-    _downloadFileLogger?.t(msg, stackTrace: StackTrace.empty);
+  void download(Object msg) {
+    _safeLogCall(() async {
+      await _initLogger();
+      _consoleLogger?.t(msg, stackTrace: StackTrace.empty);
+      _downloadFileLogger?.t(msg, stackTrace: StackTrace.empty);
+    });
   }
 
   Future<void> uploadError(dynamic throwable, {dynamic stackTrace, Map<String, dynamic>? extraInfos}) async {
     /// sentry is removed
   }
 
+  void _safeLogCall(Future<void> Function() action) {
+    action().catchError((error, stackTrace) {
+      _fallbackConsole('Log write failed.', error, stackTrace is StackTrace ? stackTrace : null);
+    });
+  }
+
+  void _fallbackConsole(Object message, [Object? error, StackTrace? stackTrace]) {
+    if (kDebugMode) {
+      debugPrint('$message');
+      if (error != null) {
+        debugPrint('$error');
+      }
+      if (stackTrace != null) {
+        debugPrint('$stackTrace');
+      }
+      return;
+    }
+
+    stderr.writeln(message);
+    if (error != null) {
+      stderr.writeln(error);
+    }
+    if (stackTrace != null) {
+      stderr.writeln(stackTrace);
+    }
+  }
+
   Future<String> getSize() async {
+    if (logDirPath == null) {
+      return byte2String(0.0);
+    }
+
     return compute(
       (logDirPath) {
         Directory logDirectory = Directory(logDirPath!);
@@ -126,51 +170,80 @@ class LogService with JHLifeCircleBeanErrorCatch implements JHLifeCircleBean {
     _warningFileLogger = null;
     _downloadFileLogger = null;
 
-    if (await Directory(logDirPath!).exists()) {
+    if (logDirPath != null && await Directory(logDirPath!).exists()) {
       await Directory(logDirPath!).delete(recursive: true);
     }
   }
 
   Future<void> _initLogDir() async {
-    if (logDirPath == null) {
-      logDirPath = path.join(pathService.getVisibleDir().path, 'logs');
-      if (!await Directory(logDirPath!).exists()) {
-        await Directory(logDirPath!).create();
-      }
+    if (logDirPath != null || _disableFileLogging) {
+      return;
+    }
+
+    final Directory? baseDir = pathService.appSupportDir ?? pathService.appDocDir ?? pathService.externalStorageDir;
+    if (baseDir == null) {
+      _disableFileLogging = true;
+      _fallbackConsole('Init log dir failed: no available base directory, fallback to console logging.');
+      return;
+    }
+
+    try {
+      logDirPath = path.join(baseDir.path, 'logs');
+      await Directory(logDirPath!).create(recursive: true);
+    } catch (e, s) {
+      logDirPath = null;
+      _disableFileLogging = true;
+      _fallbackConsole('Init log dir failed, fallback to console logging.', e, s);
     }
   }
 
   Future<void> _initLogger() async {
     _consoleLogger ??= Logger(printer: devPrinter);
+    await _consoleLogger!.init;
 
     await _initLogDir();
-    String fileName = DateFormat('yyyy-MM-dd_HH-mm-ss').format(DateTime.now());
-
-    _verboseFileLogger ??= Logger(
-      printer: HybridPrinter(prodPrinterWithBox, trace: prodPrinterWithoutBox, debug: prodPrinterWithoutBox, info: prodPrinterWithoutBox),
-      filter: EHLogFilter(),
-      output: FileOutput(file: File(path.join(logDirPath!, '$fileName.log'))),
-    );
-    if (advancedSetting.enableVerboseLogging.isTrue) {
-      _warningFileLogger ??= Logger(
-        level: Level.warning,
-        printer: prodPrinterWithBox,
-        filter: ProductionFilter(),
-        output: FileOutput(file: File(path.join(logDirPath!, '${fileName}_error.log'))),
-      );
-      _downloadFileLogger ??= Logger(
-        printer: prodPrinterWithoutBox,
-        filter: ProductionFilter(),
-        output: FileOutput(file: File(path.join(logDirPath!, '${fileName}_download.log'))),
-      );
+    if (_disableFileLogging || logDirPath == null) {
+      return;
     }
 
-    await Future.wait([
-      _consoleLogger!.init,
-      _verboseFileLogger!.init,
-      if (_warningFileLogger != null) _warningFileLogger!.init,
-      if (_downloadFileLogger != null) _downloadFileLogger!.init,
-    ]);
+    String fileName = DateFormat('yyyy-MM-dd_HH-mm-ss').format(DateTime.now());
+
+    try {
+      _verboseFileLogger ??= Logger(
+        printer: HybridPrinter(prodPrinterWithBox, trace: prodPrinterWithoutBox, debug: prodPrinterWithoutBox, info: prodPrinterWithoutBox),
+        filter: EHLogFilter(),
+        output: FileOutput(file: File(path.join(logDirPath!, '$fileName.log'))),
+      );
+      if (advancedSetting.enableVerboseLogging.isTrue) {
+        _warningFileLogger ??= Logger(
+          level: Level.warning,
+          printer: prodPrinterWithBox,
+          filter: ProductionFilter(),
+          output: FileOutput(file: File(path.join(logDirPath!, '${fileName}_error.log'))),
+        );
+        _downloadFileLogger ??= Logger(
+          printer: prodPrinterWithoutBox,
+          filter: ProductionFilter(),
+          output: FileOutput(file: File(path.join(logDirPath!, '${fileName}_download.log'))),
+        );
+      }
+
+      await Future.wait([
+        _verboseFileLogger!.init,
+        if (_warningFileLogger != null) _warningFileLogger!.init,
+        if (_downloadFileLogger != null) _downloadFileLogger!.init,
+      ]);
+    } catch (e, s) {
+      _disableFileLogging = true;
+      logDirPath = null;
+      await _verboseFileLogger?.close();
+      await _warningFileLogger?.close();
+      await _downloadFileLogger?.close();
+      _verboseFileLogger = null;
+      _warningFileLogger = null;
+      _downloadFileLogger = null;
+      _fallbackConsole('Init file logger failed, fallback to console logging.', e, s);
+    }
   }
 }
 

--- a/lib/src/service/path_service.dart
+++ b/lib/src/service/path_service.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:get/get.dart';
 import 'package:path_provider/path_provider.dart';
 
@@ -8,6 +9,8 @@ import 'jh_service.dart';
 PathService pathService = PathService();
 
 class PathService with JHLifeCircleBeanErrorCatch implements JHLifeCircleBean {
+  static const int android16SdkInt = 36;
+
   /// visible for all
   late Directory tempDir;
 
@@ -21,6 +24,9 @@ class PathService with JHLifeCircleBeanErrorCatch implements JHLifeCircleBean {
   Directory? externalStorageDir;
 
   Directory? systemDownloadDir;
+  int? androidSdkInt;
+
+  bool get isAndroid16OrAbove => Platform.isAndroid && (androidSdkInt ?? 0) >= android16SdkInt;
 
   @override
   List<JHLifeCircleBean> get initDependencies => [];
@@ -28,20 +34,72 @@ class PathService with JHLifeCircleBeanErrorCatch implements JHLifeCircleBean {
   @override
   Future<void> doInitBean() async {
     await Future.wait([
-      getTemporaryDirectory().then((value) => tempDir = value),
-      getApplicationDocumentsDirectory().then((value) => appDocDir = value).catchError((error) => null),
-      getApplicationSupportDirectory().then((value) => appSupportDir = value).catchError((error) => null),
-      getExternalStorageDirectory().then((value) => externalStorageDir = value).catchError((error) => null),
-      getDownloadsDirectory().then((value) => systemDownloadDir = value).catchError((error) => null),
+      () async {
+        tempDir = await getTemporaryDirectory();
+      }(),
+      () async {
+        try {
+          appDocDir = await getApplicationDocumentsDirectory();
+        } catch (_) {}
+      }(),
+      () async {
+        try {
+          appSupportDir = await getApplicationSupportDirectory();
+        } catch (_) {}
+      }(),
+      () async {
+        try {
+          externalStorageDir = await getExternalStorageDirectory();
+        } catch (_) {}
+      }(),
+      () async {
+        try {
+          systemDownloadDir = await getDownloadsDirectory();
+        } catch (_) {}
+      }(),
+      if (Platform.isAndroid)
+        () async {
+          try {
+            androidSdkInt = (await DeviceInfoPlugin().androidInfo).version.sdkInt;
+          } catch (_) {
+            androidSdkInt = _parseSdkIntFromOperatingSystemVersion();
+          }
+        }(),
     ]);
   }
 
   @override
   Future<void> doAfterBeanReady() async {}
 
+  Directory getInternalRootDir() {
+    return appSupportDir ?? appDocDir ?? tempDir;
+  }
+
+  bool isRestrictedAndroidDataPath(String rawPath) {
+    if (!Platform.isAndroid || !isAndroid16OrAbove) {
+      return false;
+    }
+
+    final String normalizedPath = rawPath.replaceAll('\\', '/').toLowerCase();
+    return normalizedPath.contains('/android/data/');
+  }
+
+  int? _parseSdkIntFromOperatingSystemVersion() {
+    final RegExpMatch? match = RegExp(r'sdk\s*(\d+)', caseSensitive: false).firstMatch(Platform.operatingSystemVersion);
+    if (match == null) {
+      return null;
+    }
+    return int.tryParse(match.group(1)!);
+  }
+
   Directory getVisibleDir() {
-    if (Platform.isAndroid && externalStorageDir != null) {
-      return externalStorageDir!;
+    if (Platform.isAndroid) {
+      if (isAndroid16OrAbove) {
+        return getInternalRootDir();
+      }
+      if (externalStorageDir != null) {
+        return externalStorageDir!;
+      }
     }
     if (GetPlatform.isWindows && appSupportDir != null) {
       return appSupportDir!;
@@ -49,6 +107,6 @@ class PathService with JHLifeCircleBeanErrorCatch implements JHLifeCircleBean {
     if (GetPlatform.isLinux && appSupportDir != null) {
       return appSupportDir!;
     }
-    return appDocDir ?? appSupportDir ?? systemDownloadDir!;
+    return appDocDir ?? appSupportDir ?? systemDownloadDir ?? tempDir;
   }
 }

--- a/lib/src/service/storage_service.dart
+++ b/lib/src/service/storage_service.dart
@@ -12,48 +12,136 @@ StorageService storageService = StorageService();
 class StorageService with JHLifeCircleBeanErrorCatch implements JHLifeCircleBean {
   static const String storageFileName = 'jhentai';
 
-  late final GetStorage _storage;
+  GetStorage? _storage;
+  bool _storageAvailable = false;
+
+  Directory _resolveStorageBaseDir() {
+    return pathService.appSupportDir ?? pathService.appDocDir ?? pathService.externalStorageDir ?? pathService.tempDir;
+  }
 
   @override
   Future<void> doInitBean() async {
-    _migrateOldConfigFile();
-    _storage = GetStorage(storageFileName, pathService.getVisibleDir().path);
-    await _storage.initStorage;
+    final Directory storageDir = Directory(join(_resolveStorageBaseDir().path, 'storage'));
+    try {
+      await storageDir.create(recursive: true);
+      await _migrateOldConfigFile(storageDir);
+
+      _storage = GetStorage(storageFileName, storageDir.path);
+      await _storage!.initStorage;
+      _storageAvailable = true;
+    } catch (e, s) {
+      _storageAvailable = false;
+      _storage = null;
+      log.error('Init StorageService failed, fallback to disabled storage', e, s);
+    }
   }
 
   @override
   Future<void> doAfterBeanReady() async {}
 
   Future<void> write(String key, dynamic value) {
-    return _storage.write(key, value);
+    if (!_storageAvailable || _storage == null) {
+      return Future.value();
+    }
+
+    try {
+      return _storage!.write(key, value);
+    } catch (e, s) {
+      log.error('StorageService write failed: $key', e, s);
+      return Future.value();
+    }
   }
 
   T? read<T>(String key) {
-    return _storage.read(key);
+    if (!_storageAvailable || _storage == null) {
+      return null;
+    }
+
+    try {
+      return _storage!.read(key);
+    } catch (e, s) {
+      log.error('StorageService read failed: $key', e, s);
+      return null;
+    }
   }
 
-  T getKeys<T>() {
-    return _storage.getKeys();
+  Iterable<String>? getKeys() {
+    if (!_storageAvailable || _storage == null) {
+      return null;
+    }
+
+    try {
+      return _storage!.getKeys().whereType<String>();
+    } catch (e, s) {
+      log.error('StorageService getKeys failed', e, s);
+      return null;
+    }
   }
   
   Future<void> remove(String key) async {
-    _storage.remove(key);
+    if (!_storageAvailable || _storage == null) {
+      return;
+    }
+
+    try {
+      _storage!.remove(key);
+    } catch (e, s) {
+      log.error('StorageService remove failed: $key', e, s);
+    }
   }
 
-  void _migrateOldConfigFile() {
+  Future<void> _migrateOldConfigFile(Directory targetDir) async {
+    final File targetConfig = File(join(targetDir.path, '$storageFileName.gs'));
+    final File targetBak = File(join(targetDir.path, '$storageFileName.bak'));
+    final List<Directory> legacyDirs = [
+      if (pathService.externalStorageDir != null) pathService.externalStorageDir!,
+      if (pathService.appDocDir != null) pathService.appDocDir!,
+      if (pathService.appSupportDir != null) pathService.appSupportDir!,
+    ];
+
+    Future<void> copyFirstExisting(List<File> candidates, File target) async {
+      if (await target.exists()) {
+        return;
+      }
+
+      for (File source in candidates) {
+        if (source.path == target.path) {
+          continue;
+        }
+
+        try {
+          if (await source.exists()) {
+            await target.parent.create(recursive: true);
+            await source.copy(target.path);
+            return;
+          }
+        } catch (_) {
+          continue;
+        }
+      }
+    }
+
     try {
-      File oldConfigFile = File(join(pathService.getVisibleDir().path, '.GetStorage.gs'));
-      File oldBakFile = File(join(pathService.getVisibleDir().path, '.GetStorage.bak'));
-      if (oldConfigFile.existsSync()) {
-        oldConfigFile.copySync(join(pathService.getVisibleDir().path, 'jhentai.gs'));
-        oldConfigFile.delete();
-      }
-      if (oldBakFile.existsSync()) {
-        oldBakFile.copySync(join(pathService.getVisibleDir().path, 'jhentai.bak'));
-        oldBakFile.delete();
-      }
-    } on Exception catch (e) {
-      log.uploadError(e);
+      await copyFirstExisting(
+        legacyDirs
+            .expand((dir) => [
+                  File(join(dir.path, '$storageFileName.gs')),
+                  File(join(dir.path, '.GetStorage.gs')),
+                ])
+            .toList(),
+        targetConfig,
+      );
+      await copyFirstExisting(
+        legacyDirs
+            .expand((dir) => [
+                  File(join(dir.path, '$storageFileName.bak')),
+                  File(join(dir.path, '.GetStorage.bak')),
+                ])
+            .toList(),
+        targetBak,
+      );
+    } catch (e, s) {
+      log.error('Migrate old GetStorage files failed', e, s);
     }
   }
 }

--- a/lib/src/service/storage_service.dart
+++ b/lib/src/service/storage_service.dart
@@ -16,6 +16,10 @@ class StorageService with JHLifeCircleBeanErrorCatch implements JHLifeCircleBean
   bool _storageAvailable = false;
 
   Directory _resolveStorageBaseDir() {
+    if (pathService.isAndroid16OrAbove) {
+      return pathService.getInternalRootDir();
+    }
+
     return pathService.appSupportDir ?? pathService.appDocDir ?? pathService.externalStorageDir ?? pathService.tempDir;
   }
 
@@ -91,6 +95,10 @@ class StorageService with JHLifeCircleBeanErrorCatch implements JHLifeCircleBean
   }
 
   Future<void> _migrateOldConfigFile(Directory targetDir) async {
+    if (pathService.isAndroid16OrAbove) {
+      return;
+    }
+
     final File targetConfig = File(join(targetDir.path, '$storageFileName.gs'));
     final File targetBak = File(join(targetDir.path, '$storageFileName.bak'));
     final List<Directory> legacyDirs = [

--- a/lib/src/setting/download_setting.dart
+++ b/lib/src/setting/download_setting.dart
@@ -39,14 +39,17 @@ class DownloadSetting with JHLifeCircleBeanWithConfigStorage implements JHLifeCi
   @override
   void applyBeanConfig(String configString) {
     Map map = jsonDecode(configString);
+    final bool forceInternalStorage = pathService.isAndroid16OrAbove;
 
     if (!GetPlatform.isIOS) {
-      downloadPath.value = map['downloadPath'] ?? downloadPath.value;
-      singleImageSavePath.value = map['singleImageSavePath'] ?? singleImageSavePath.value;
+      if (!forceInternalStorage) {
+        downloadPath.value = map['downloadPath'] ?? downloadPath.value;
+        singleImageSavePath.value = map['singleImageSavePath'] ?? singleImageSavePath.value;
+      }
     }
-    if (map['extraGalleryScanPath'] != null) {
+    if (map['extraGalleryScanPath'] != null && !forceInternalStorage) {
       extraGalleryScanPath.addAll(map['extraGalleryScanPath'].cast<String>());
-      extraGalleryScanPath.value = extraGalleryScanPath.toSet().toList();
+      extraGalleryScanPath.assignAll(extraGalleryScanPath.toSet().toList());
     }
     downloadOriginalImageByDefault.value = map['downloadOriginalImageByDefault'] ?? downloadOriginalImageByDefault.value;
     defaultGalleryGroup.value = map['defaultGalleryGroup'];
@@ -63,6 +66,12 @@ class DownloadSetting with JHLifeCircleBeanWithConfigStorage implements JHLifeCi
     manageArchiveDownloadConcurrency.value = map['manageArchiveDownloadConcurrency'] ?? manageArchiveDownloadConcurrency.value;
     deleteArchiveFileAfterDownload.value = map['deleteArchiveFileAfterDownload'] ?? deleteArchiveFileAfterDownload.value;
     restoreTasksAutomatically.value = map['restoreTasksAutomatically'] ?? restoreTasksAutomatically.value;
+
+    if (forceInternalStorage) {
+      downloadPath.value = defaultDownloadPath;
+      extraGalleryScanPath.assignAll([defaultExtraGalleryScanPath]);
+      singleImageSavePath.value = join(pathService.getVisibleDir().path, 'save');
+    }
   }
 
   @override


### PR DESCRIPTION
### Fix #731: Android 16 startup crash caused by hardcoded external storage path

On Android 16 the app crashes at startup with:

```
PathAccessException: Creation failed, path = 
'/storage/emulated/0/Android/data/top.jtmonster.jhentai'
(OS Error: Permission denied, errno = 13)

```
Root cause:

The app manually creates and writes to a hardcoded external path under
/storage/emulated/0/Android/data/<package> during initialization (GetStorage + drift DB).
Android 16 further restricts direct access to this path, causing directory creation to fail.
The exception was not safely handled, which led to service init failure and app exit.

What was changed

Removed hardcoded external storage root usage

StorageService (GetStorage)

drift NativeDatabase path

Switched to system-managed app directory

Use getApplicationSupportDirectory() as base directory.

Create subfolders (storage/, db/) with create(recursive: true).

Made initialization failure non-fatal

Storage and DB initialization wrapped with safe fallback.

Avoid LateInitializationError.

On failure, degrade instead of crashing.

Added legacy data migration

If old external DB/storage exists and is accessible, migrate.

If not accessible, skip without affecting startup.

Result

App no longer crashes on Android 16.

GetStorage and drift DB are created under internal app support directory.

Startup is resilient to storage permission changes.

No new dependencies introduced.

### 修复：Android 16 启动阶段因外部存储路径访问失败导致崩溃

在 Android 16 上应用冷启动会直接崩溃，日志显示：
```
PathAccessException: Creation failed, path =
'/storage/emulated/0/Android/data/top.jtmonster.jhentai'
(OS Error: Permission denied, errno = 13)
```
### 问题原因

启动阶段存在对硬编码外部路径
/storage/emulated/0/Android/data/<package>
的直接创建/写入行为（主要涉及 GetStorage 和 drift 数据库）。

Android 16 对该路径访问限制更严格，目录创建失败后异常未被安全处理，导致：
StorageService 初始化失败、drift 数据库打开失败、启动流程中断并退出

本次修改内容
1.移除硬编码外部路径使用
StorageService（GetStorage）
drift NativeDatabase 路径
2.改为使用系统分配的应用内部目录
使用 getApplicationSupportDirectory() 作为基础目录，在其下创建 storage/、db/ 子目录，所有目录创建统一使用 create(recursive: true)
3.启动阶段异常改为降级处理
存储与数据库初始化增加安全兜底，避免 LateInitializationError初始化失败不再导致应用崩溃
4.增加旧数据迁移逻辑
若旧外部目录可访问则迁移
若不可访问则跳过，不影响启动

修改结果
Android 16 真机冷启动不再崩溃
GetStorage 与 drift 数据库改为内部目录
启动流程对存储权限变化具备容错能力
（未新增依赖，仅调整路径与初始化逻辑）

**《我修我自己》**

自行本地build了一个debug apk，android16设备启动无黑屏功能基本正常