### PR TITLE
feat: 为桌面模式和鼠标右键改用普通弹出菜单

### DIFF
--- a/lib/src/pages/read/layout/base/base_layout.dart
+++ b/lib/src/pages/read/layout/base/base_layout.dart
@@ -6,6 +6,7 @@ import 'package:get/get.dart';
 import 'package:jhentai/src/extension/get_logic_extension.dart';
 import 'package:jhentai/src/model/read_page_info.dart';
 import 'package:jhentai/src/setting/read_setting.dart';
+import 'package:jhentai/src/setting/style_setting.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 import '../../../../config/ui_config.dart';
@@ -156,8 +157,25 @@ abstract class BaseLayout extends StatelessWidget {
 
   Widget _buildOnlineImage(BuildContext context, int index) {
     return GestureDetector(
-      onLongPress: () => logic.showBottomMenuInOnlineMode(index, context),
-      onSecondaryTap: () => logic.showBottomMenuInOnlineMode(index, context),
+      onLongPressStart: (details) {
+        if (styleSetting.isInDesktopLayout) {
+          logic.showOnlineContextMenuAtPosition(
+            index: index,
+            context: context,
+            position: details.globalPosition,
+          );
+        } else {
+          logic.showBottomMenuInOnlineMode(index, context);
+        }
+      },
+
+      onSecondaryTapDown: (details) {
+        logic.showOnlineContextMenuAtPosition(
+          index: index,
+          context: context,
+          position: details.globalPosition,
+        );
+      },
       child: EHImage(
         galleryImage: readPageState.images[index]!,
         containerWidth: logic.readPageState.imageContainerSizes[index]?.width ?? logic.getPlaceHolderSize(index).width,
@@ -258,8 +276,25 @@ abstract class BaseLayout extends StatelessWidget {
         }
 
         return GestureDetector(
-          onLongPress: () => logic.showBottomMenuInLocalMode(index, context),
-          onSecondaryTap: () => logic.showBottomMenuInLocalMode(index, context),
+          onLongPressStart: (details) {
+            if (styleSetting.isInDesktopLayout) {
+              logic.showLocalContextMenuAtPosition(
+                index: index,
+                context: context,
+                position: details.globalPosition,
+              );
+            } else {
+              logic.showBottomMenuInLocalMode(index, context);
+            }
+          },
+
+          onSecondaryTapDown: (details) {
+            logic.showLocalContextMenuAtPosition(
+              index: index,
+              context: context,
+              position: details.globalPosition,
+            );
+          },
           child: EHImage(
             galleryImage: readPageState.images[index]!.copyWith(
               path: superResolutionService.computeImageOutputRelativePath(readPageState.images[index]!.path!),
@@ -318,8 +353,25 @@ abstract class BaseLayout extends StatelessWidget {
 
   Widget _buildLocalImage(BuildContext context, int index) {
     return GestureDetector(
-      onLongPress: () => logic.showBottomMenuInLocalMode(index, context),
-      onSecondaryTap: () => logic.showBottomMenuInLocalMode(index, context),
+      onLongPressStart: (details) {
+        if (styleSetting.isInDesktopLayout) {
+          logic.showLocalContextMenuAtPosition(
+            index: index,
+            context: context,
+            position: details.globalPosition,
+          );
+        } else {
+          logic.showBottomMenuInLocalMode(index, context);
+        }
+      },
+
+      onSecondaryTapDown: (details) {
+        logic.showLocalContextMenuAtPosition(
+          index: index,
+          context: context,
+          position: details.globalPosition,
+        );
+      },
       child: EHImage(
         galleryImage: readPageState.images[index]!,
         containerWidth: logic.readPageState.imageContainerSizes[index]?.width ?? logic.getPlaceHolderSize(index).width,

--- a/lib/src/pages/read/layout/base/base_layout_logic.dart
+++ b/lib/src/pages/read/layout/base/base_layout_logic.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:flutter/material.dart';
+
 import 'package:clipboard/clipboard.dart';
 import 'package:dio/dio.dart';
 import 'package:extended_image/extended_image.dart';
@@ -28,7 +30,6 @@ import 'package:saver_gallery/saver_gallery.dart';
 import 'package:share_plus/share_plus.dart';
 import '../../../../exception/eh_image_exception.dart';
 import '../../../../model/gallery_image.dart';
-import '../../../../service/path_service.dart';
 import '../../../../setting/read_setting.dart';
 import '../../../../service/log.dart';
 import '../../../../utils/route_util.dart';
@@ -161,6 +162,57 @@ abstract class BaseLayoutLogic extends GetxController with GetTickerProviderStat
     );
   }
 
+  Future<void> showOnlineContextMenuAtPosition({
+    required int index,
+    required BuildContext context,
+    required Offset position,
+  }) async {
+    final selected = await showMenu<String>(
+      context: context,
+      position: RelativeRect.fromLTRB(
+        position.dx,
+        position.dy,
+        position.dx,
+        position.dy,
+      ),
+      items: [
+        PopupMenuItem(
+          value: 'reload',
+          child: Text('reload'.tr),
+        ),
+        PopupMenuItem(
+          value: 'share',
+          child: Text('share'.tr),
+        ),
+        PopupMenuItem(
+          value: 'save',
+          child: Text('${'save'.tr}(${'resampleImage'.tr})'),
+        ),
+        if (readPageState.images[index]!.originalImageUrl != null &&
+            userSetting.hasLoggedIn())
+          PopupMenuItem(
+            value: 'save_original',
+            child: Text('${'save'.tr}(${'originalImage'.tr})'),
+          ),
+      ],
+    );
+
+    switch (selected) {
+      case 'reload':
+        readPageLogic.reloadImage(index);
+        break;
+      case 'share':
+        shareOnlineImage(index);
+        break;
+      case 'save':
+        await saveOnlineImage(index);
+        break;
+      case 'save_original':
+        await saveOriginalOnlineImage(index);
+        break;
+    }
+  }
+
   void showBottomMenuInLocalMode(int index, BuildContext context) {
     if (galleryDownloadService.galleryDownloadInfos[readPageState.readPageInfo.gid]?.images[index]?.downloadStatus != DownloadStatus.downloaded) {
       return;
@@ -195,6 +247,59 @@ abstract class BaseLayoutLogic extends GetxController with GetTickerProviderStat
         cancelButton: CupertinoActionSheetAction(child: Text('cancel'.tr), onPressed: backRoute),
       ),
     );
+  }
+
+  Future<void> showLocalContextMenuAtPosition({
+    required int index,
+    required BuildContext context,
+    required Offset position,
+  }) async {
+    if (galleryDownloadService.galleryDownloadInfos[
+                readPageState.readPageInfo.gid]
+            ?.images[index]
+            ?.downloadStatus !=
+        DownloadStatus.downloaded) {
+      return;
+    }
+
+    final selected = await showMenu<String>(
+      context: context,
+      position: RelativeRect.fromLTRB(
+        position.dx,
+        position.dy,
+        position.dx,
+        position.dy,
+      ),
+      items: [
+        PopupMenuItem(
+          value: 'share',
+          child: Text('share'.tr),
+        ),
+        PopupMenuItem(
+          value: 'save',
+          child: Text('save'.tr),
+        ),
+        PopupMenuItem(
+          value: 'redownload',
+          child: Text('reDownload'.tr),
+        ),
+      ],
+    );
+
+    switch (selected) {
+      case 'share':
+        shareLocalImage(index);
+        break;
+      case 'save':
+        saveLocalImage(index);
+        break;
+      case 'redownload':
+        galleryDownloadService.reDownloadImage(
+          readPageState.readPageInfo.gid!,
+          index,
+        );
+        break;
+    }
   }
 
   void shareOnlineImage(int index) async {


### PR DESCRIPTION
现在阅读器中，在桌面模式下长按，以及所有模式下的鼠标右键点击事件，改用为在手指/鼠标位置弹出的菜单。
这样能够缩短鼠标移动距离，同时对于大平板用户，也可以切换到桌面模式后采用普通弹出菜单来缩短手指移动距离（我比较常用桌面模式，所以只改了它）。