### PR TITLE
docs: add Fedora/dnf install instructions to the Linux section

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ Install for MacOS(No maintenance): download .dmg.
 Install for Linux(No maintenance): download Linux-amd64.deb or Linux-x86_64.AppImage due to your platform, then install
 or execute it (You may need to install webkit2gtk-4.1).
 
+Fedora-based dnf linux distro:
+
+```bash
+sudo rpm --import https://meeks233.github.io/Jhentai-rpm/fedora/RPM-GPG-KEY-jhentai
+sudo curl -fsSL -o /etc/yum.repos.d/jhentai.repo https://meeks233.github.io/Jhentai-rpm/fedora/jhentai.repo
+sudo dnf install -y jhentai
+```
+
 
 - If you use a proxy server, set proxy address at network setting page.
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -62,6 +62,14 @@ MacOS安装（不维护）： 下载dmg后安装即可。
 
 Linux安装（不维护）：根据你的系统选择 Linux-amd64.deb 或 Linux-x86_64.AppImage，下载后安装运行即可。(视需要你可能需要安装webkit2gtk-4.1)
 
+基于 Fedora 的 dnf Linux 发行版：
+
+```bash
+sudo rpm --import https://meeks233.github.io/Jhentai-rpm/fedora/RPM-GPG-KEY-jhentai
+sudo curl -fsSL -o /etc/yum.repos.d/jhentai.repo https://meeks233.github.io/Jhentai-rpm/fedora/jhentai.repo
+sudo dnf install -y jhentai
+```
+
 - 如果你使用了代理服务器，在网络设置里配置代理地址。
 
 ## 更新

--- a/README_kr.md
+++ b/README_kr.md
@@ -53,6 +53,14 @@ MacOS 설치(지원 중지): .dmg 파일을 다운로드합니다. 만약 프록
 
 Linux 설치(지원 중지): Linux_xxx.zip 파일을 다운로드하고 압축 해제를 하세요. 만약 프록시 서버를 이용한다면 네트워크 설정에서 프록시 주소를 설정해 주세요.
 
+Fedora 기반 dnf Linux 배포판:
+
+```bash
+sudo rpm --import https://meeks233.github.io/Jhentai-rpm/fedora/RPM-GPG-KEY-jhentai
+sudo curl -fsSL -o /etc/yum.repos.d/jhentai.repo https://meeks233.github.io/Jhentai-rpm/fedora/jhentai.repo
+sudo dnf install -y jhentai
+```
+
 ## 개발 동기
 
 저의 첫 Flutter 프로젝트입니다. 저는 개발 중에 Flutter에 익숙해지는 것을 목표로 합니다. 제가 사용하는 기기는 Android 폰, iPad, Windows 컴퓨터입니다. 기존 E-hentai 앱들은


### PR DESCRIPTION
因为本人在使用Fedora-based发行版需要使用Jhentai，但是又没有官方构建，所以自己fork然后让claude code搞了一个开源构建仓库，每天定时action检验上游release版本号然后自动构建，已经测试并跑通了整个流程，我用的KDE桌面打开没有发现bug。

相关代码都在repo里，需要审计可以看我仓库里的docs/upstream-pr-draft.md。反正我肯定是有时间和机会维护的，因为我经常使用（意味深

感谢开发

<img width="2050" height="1170" alt="Screenshot_20260629_131114" src="https://github.com/user-attachments/assets/4006c1f7-a705-4fe6-94b9-095ff1ab6440" />
<img width="2050" height="1170" alt="Screenshot_20260629_131251" src="https://github.com/user-attachments/assets/b2343079-9c64-4b74-a7bd-c326a90b4bb8" />
<img width="2050" height="1170" alt="Screenshot_20260629_131331" src="https://github.com/user-attachments/assets/d94eba11-29d8-468f-92b3-3d6ca2c483de" />

