### PR TITLE
feat: decimal minimum rating with slider and client-side filter

### DIFF
--- a/lib/src/l18n/en_US.dart
+++ b/lib/src/l18n/en_US.dart
@@ -663,6 +663,7 @@ class en_US {
       'pageRangeSelectHint': 'min <= 1000, max >= 10\nmin/max <= 0.8, max-min >= 20',
       'to': 'to',
       'minimumRating': 'Minimum Rating',
+      'noLimit': 'No Limit',
       'disableFilterForLanguage': 'Disable Filter For Language',
       'disableFilterForUploader': 'Disable Filter For Uploader',
       'disableFilterForTags': 'Disable Filter For Tags',

--- a/lib/src/l18n/ko_KR.dart
+++ b/lib/src/l18n/ko_KR.dart
@@ -663,6 +663,7 @@ class ko_KR {
       'pageRangeSelectHint': '최소 ≤ 1000, 최대 ≥ 10\n최소/최대 ≤ 0.8, 최대-최소 ≥ 20',
       'to': '~',
       'minimumRating': '최소 점수',
+      'noLimit': '제한 없음',
       'disableFilterForLanguage': '언어 필터 사용 안 함',
       'disableFilterForUploader': '업로더 필터 사용 안 함',
       'disableFilterForTags': '태그 필터 사용 안 함',

--- a/lib/src/l18n/pt_BR.dart
+++ b/lib/src/l18n/pt_BR.dart
@@ -664,6 +664,7 @@ class pt_BR {
       'pageRangeSelectHint': 'min <= 1000, max >= 10\nmin/max <= 0.8, max-min >= 20',
       'to': 'para',
       'minimumRating': 'Classificação mínima',
+      'noLimit': 'Sem limite',
       'disableFilterForLanguage': 'Desativar filtro para idioma',
       'disableFilterForUploader': 'Desativar filtro para uploader',
       'disableFilterForTags': 'Desativar filtro para Tags',

--- a/lib/src/l18n/ru_RU.dart
+++ b/lib/src/l18n/ru_RU.dart
@@ -672,6 +672,7 @@ class ru_RU {
       'pageRangeSelectHint': 'мин <= 1000, макс >= 10\nмин/макс <= 0.8, макс-мин >= 20',
       'to': 'до',
       'minimumRating': 'Минимальный рейтинг',
+      'noLimit': 'Без ограничений',
       'disableFilterForLanguage': 'Отключить фильтр по языку',
       'disableFilterForUploader': 'Отключить фильтр по загрузившему',
       'disableFilterForTags': 'Отключить фильтр по тегам',

--- a/lib/src/l18n/zh_CN.dart
+++ b/lib/src/l18n/zh_CN.dart
@@ -663,6 +663,7 @@ class zh_CN {
       'pageRangeSelectHint': 'min <= 1000, max >= 10\nmin/max <= 0.8, max-min >= 20',
       'to': '到',
       'minimumRating': '最低评分',
+      'noLimit': '不限',
       'disableFilterForLanguage': '禁用语言过滤',
       'disableFilterForUploader': '禁用上传者过滤',
       'disableFilterForTags': '禁用标签过滤',

--- a/lib/src/l18n/zh_TW.dart
+++ b/lib/src/l18n/zh_TW.dart
@@ -663,6 +663,7 @@ class zh_TW {
       'pageRangeSelectHint': 'min <= 1000, max >= 10\nmin/max <= 0.8, max-min >= 20',
       'to': '到',
       'minimumRating': '最低評分',
+      'noLimit': '不限',
       'disableFilterForLanguage': '停用語言過濾',
       'disableFilterForUploader': '停用上傳者過濾',
       'disableFilterForTags': '停用標籤過濾',

--- a/lib/src/model/search_config.dart
+++ b/lib/src/model/search_config.dart
@@ -38,7 +38,7 @@ class SearchConfig {
   int? pageAtLeast;
   int? pageAtMost;
 
-  int minimumRating = 1;
+  double minimumRating = 1;
 
   bool disableFilterForLanguage = false;
   bool disableFilterForUploader = false;
@@ -171,7 +171,7 @@ class SearchConfig {
       }
 
       if (minimumRating > 1) {
-        params['f_srdd'] = minimumRating;
+        params['f_srdd'] = minimumRating.floor();
       }
 
       if (disableFilterForLanguage) {
@@ -337,7 +337,7 @@ class SearchConfig {
     bool? onlyShowGalleriesWithTorrents,
     int? pageAtLeast,
     int? pageAtMost,
-    int? minimumRating,
+    double? minimumRating,
     bool? disableFilterForLanguage,
     bool? disableFilterForUploader,
     bool? disableFilterForTags,

--- a/lib/src/pages/base/base_page_logic.dart
+++ b/lib/src/pages/base/base_page_logic.dart
@@ -423,6 +423,8 @@ abstract class BasePageLogic extends GetxController with Scroll2TopLogicMixin {
 
     List<Gallery> filteredGallerys = await _filterByBlockingRules(gallerys);
 
+    filteredGallerys = _filterByMinimumRating(filteredGallerys);
+
     if (preferenceSetting.preloadGalleryCover.isTrue) {
       for (Gallery gallery in gallerys) {
         getNetworkImageData(gallery.cover.url, useCache: true);
@@ -449,6 +451,13 @@ abstract class BasePageLogic extends GetxController with Scroll2TopLogicMixin {
     } else {
       return newGallerys.sublist(0, 1).map((g) => g..blockedByLocalRules = true).toList();
     }
+  }
+
+  List<Gallery> _filterByMinimumRating(List<Gallery> gallerys) {
+    if (state.searchConfig.minimumRating <= 1) {
+      return gallerys;
+    }
+    return gallerys.where((g) => g.rating >= state.searchConfig.minimumRating).toList();
   }
 
   Future<void> _translateGalleryTagsIfNeeded(List<Gallery> gallerys) async {

--- a/lib/src/pages/base/base_page_logic.dart
+++ b/lib/src/pages/base/base_page_logic.dart
@@ -457,7 +457,16 @@ abstract class BasePageLogic extends GetxController with Scroll2TopLogicMixin {
     if (state.searchConfig.minimumRating <= 1) {
       return gallerys;
     }
-    return gallerys.where((g) => g.rating >= state.searchConfig.minimumRating).toList();
+    List<Gallery> filteredGallerys =
+        gallerys.where((g) => g.rating >= state.searchConfig.minimumRating).toList();
+    if (filteredGallerys.isNotEmpty) {
+      return filteredGallerys;
+    } else {
+      // If all gallerys are filtered out by the minimum rating, keep the first
+      // one (marked) to indicate the filter state. Otherwise the UI would keep
+      // loading subsequent pages and appear stuck in a loading state.
+      return gallerys.sublist(0, 1).map((g) => g..blockedByLocalRules = true).toList();
+    }
   }
 
   Future<void> _translateGalleryTagsIfNeeded(List<Gallery> gallerys) async {

--- a/lib/src/widget/eh_search_config_dialog.dart
+++ b/lib/src/widget/eh_search_config_dialog.dart
@@ -619,25 +619,27 @@ class _EHSearchConfigDialogState extends State<EHSearchConfigDialog> {
     return ListTile(
       dense: true,
       contentPadding: EdgeInsets.zero,
-      title: Text('minimumRating'.tr, style: const TextStyle(fontSize: 15)),
-      trailing: SizedBox(
-        width: 50,
-        child: DropdownButton<int>(
-          value: searchConfig.minimumRating,
-          elevation: 4,
-          onChanged: (int? newValue) {
-            setState(() {
-              searchConfig.minimumRating = newValue!;
-            });
-          },
-          items: const [
-            DropdownMenuItem(child: Text('1'), value: 1),
-            DropdownMenuItem(child: Text('2'), value: 2),
-            DropdownMenuItem(child: Text('3'), value: 3),
-            DropdownMenuItem(child: Text('4'), value: 4),
-            DropdownMenuItem(child: Text('5'), value: 5),
-          ],
-        ),
+      title: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text('minimumRating'.tr, style: const TextStyle(fontSize: 15)),
+          Text(
+            searchConfig.minimumRating == 1 ? 'noLimit'.tr : '${searchConfig.minimumRating.toStringAsFixed(1)} ★',
+            style: TextStyle(fontSize: 15, fontWeight: FontWeight.bold),
+          ),
+        ],
+      ),
+      subtitle: Slider(
+        value: searchConfig.minimumRating.clamp(1.0, 5.0),
+        min: 1.0,
+        max: 5.0,
+        divisions: 8,
+        label: searchConfig.minimumRating == 1 ? 'noLimit'.tr : searchConfig.minimumRating.toStringAsFixed(1),
+        onChanged: (double newValue) {
+          setState(() {
+            searchConfig.minimumRating = newValue;
+          });
+        },
       ),
     );
   }


### PR DESCRIPTION
## Summary

This PR replaces the integer-only minimum rating dropdown (1-5) with a slider supporting 0.5-step values (1.0-5.0), and adds client-side filtering to achieve fractional precision despite the E-Hentai API limitation.

## Changes

- `SearchConfig.minimumRating`: `int` -> `double`
- `toQueryParameters()`: floor `minimumRating` before sending `f_srdd` (E-Hentai API only accepts integers)
- Search config dialog: `DropdownButton<int>` replaced with `Slider` (divisions: 8, step: 0.5, default 1.0 = no limit)
- `BasePageLogic.postHandleNewGallerys()`: filters gallery list where `rating >= minimumRating` after receiving results
- i18n: added `noLimit` key for all 6 languages

## Why client-side filtering?

E-Hentai's `f_srdd` parameter only accepts integer values (2/3/4/5). When the user sets e.g. 3.5, the app sends `f_srdd=3` (floor, over-fetches), then the client filters results to `rating >= 3.5`. The search page displays ratings at 0.5 granularity, so filtering precision matches the available data.

## Files Changed

| File | Change |
|------|--------|
| `lib/src/model/search_config.dart` | `int` -> `double`, floor in `toQueryParameters()` |
| `lib/src/widget/eh_search_config_dialog.dart` | Dropdown -> Slider widget |
| `lib/src/pages/base/base_page_logic.dart` | `_filterByMinimumRating()` in post-processing |
| `lib/src/l18n/*.dart` (x6) | `noLimit` translation key |
