### PR TITLE
feat: 排序下载分组、确认下载性能优化

### DIFF
--- a/lib/src/l18n/en_US.dart
+++ b/lib/src/l18n/en_US.dart
@@ -710,6 +710,7 @@ class en_US {
       'originalImage': 'Original',
       'resampleImage': 'Resample',
       'defaultGalleryGroup': 'Default Gallery Group',
+      'prioritizeRecentGalleryGroups': 'Prioritize Recently Used Gallery Groups',
       'defaultArchiveGroup': 'Default Archive Group',
       'never': 'Never',
       'manual': 'Manual',

--- a/lib/src/l18n/ko_KR.dart
+++ b/lib/src/l18n/ko_KR.dart
@@ -709,6 +709,7 @@ class ko_KR {
       'originalImage': '원본',
       'resampleImage': '압축',
       'defaultGalleryGroup': 'Default Gallery Group',
+      'prioritizeRecentGalleryGroups': '최근 사용한 갤러리 그룹 우선',
       'defaultArchiveGroup': 'Default Archive Group',
       'never': '영원히 안 함',
       'manual': '수동',

--- a/lib/src/l18n/pt_BR.dart
+++ b/lib/src/l18n/pt_BR.dart
@@ -711,6 +711,7 @@ class pt_BR {
       'originalImage': 'Original',
       'resampleImage': 'Redimensionada',
       'defaultGalleryGroup': 'Default Gallery Group',
+      'prioritizeRecentGalleryGroups': 'Priorizar grupos de galeria usados recentemente',
       'defaultArchiveGroup': 'Default Archive Group',
       'never': 'Nunca',
       'manual': 'Manual',

--- a/lib/src/l18n/ru_RU.dart
+++ b/lib/src/l18n/ru_RU.dart
@@ -719,6 +719,7 @@ class ru_RU {
       'originalImage': 'Оригинал',
       'resampleImage': 'Уменьшенное',
       'defaultGalleryGroup': 'Группа галерей по умолчанию',
+      'prioritizeRecentGalleryGroups': 'Недавние группы галерей в начале списка',
       'defaultArchiveGroup': 'Группа архивов по умолчанию',
       'never': 'Никогда',
       'manual': 'Вручную',

--- a/lib/src/l18n/zh_CN.dart
+++ b/lib/src/l18n/zh_CN.dart
@@ -716,6 +716,7 @@ favnote：匹配收藏备注
       'originalImage': '原图',
       'resampleImage': '压缩',
       'defaultGalleryGroup': '默认分组（下载）',
+      'prioritizeRecentGalleryGroups': '最近使用的下载分组优先',
       'defaultArchiveGroup': '默认分组（归档）',
       'never': '从不',
       'manual': '手动',

--- a/lib/src/l18n/zh_TW.dart
+++ b/lib/src/l18n/zh_TW.dart
@@ -716,6 +716,7 @@ favnote：配對收藏備註
       'originalImage': '原圖',
       'resampleImage': '壓縮',
       'defaultGalleryGroup': '預設分組（下載）',
+      'prioritizeRecentGalleryGroups': '最近使用的下載分組優先',
       'defaultArchiveGroup': '預設分組（歸檔）',
       'never': '從不',
       'manual': '手動',

--- a/lib/src/pages/details/details_page_logic.dart
+++ b/lib/src/pages/details/details_page_logic.dart
@@ -358,6 +358,7 @@ class DetailsPageLogic extends GetxController with LoginRequiredMixin, Scroll2To
           candidates: galleryDownloadService.allGroups,
           showDownloadOriginalImageCheckBox: userSetting.hasLoggedIn(),
           downloadOriginalImage: downloadSetting.downloadOriginalImageByDefault.value,
+          preferredGroups: downloadSetting.recentGalleryGroups,
         ),
       );
 
@@ -368,6 +369,8 @@ class DetailsPageLogic extends GetxController with LoginRequiredMixin, Scroll2To
       if (state.gallery == null && state.galleryDetails == null) {
         return;
       }
+
+      unawaited(downloadSetting.saveRecentGalleryGroup(result.group));
 
       GalleryDownloadedData galleryDownloadedData = GalleryDownloadedData(
         gid: state.galleryDetails?.galleryUrl.gid ?? state.gallery!.galleryUrl.gid,

--- a/lib/src/pages/details/details_page_logic.dart
+++ b/lib/src/pages/details/details_page_logic.dart
@@ -358,7 +358,7 @@ class DetailsPageLogic extends GetxController with LoginRequiredMixin, Scroll2To
           candidates: galleryDownloadService.allGroups,
           showDownloadOriginalImageCheckBox: userSetting.hasLoggedIn(),
           downloadOriginalImage: downloadSetting.downloadOriginalImageByDefault.value,
-          preferredGroups: downloadSetting.recentGalleryGroups,
+          preferredGroups: downloadSetting.preferredGalleryGroups,
         ),
       );
 

--- a/lib/src/pages/setting/download/setting_download_page.dart
+++ b/lib/src/pages/setting/download/setting_download_page.dart
@@ -59,6 +59,7 @@ class _SettingDownloadPageState extends State<SettingDownloadPage> {
               if (GetPlatform.isDesktop) _buildSingleImageSavePath(),
               _buildDownloadOriginalImage(),
               _buildDefaultGalleryGroup(context),
+              _buildPrioritizeRecentGalleryGroups(),
               _buildDefaultArchiveGroup(context),
               _buildArchiveBotSettings(),
               _buildDownloadConcurrency(),
@@ -178,6 +179,14 @@ class _SettingDownloadPageState extends State<SettingDownloadPage> {
         onLongPress: () {
           downloadSetting.saveDefaultArchiveGroup(null);
         }).marginOnly(right: 12);
+  }
+
+  Widget _buildPrioritizeRecentGalleryGroups() {
+    return SwitchListTile(
+      title: Text('prioritizeRecentGalleryGroups'.tr),
+      value: downloadSetting.prioritizeRecentGalleryGroups.value,
+      onChanged: downloadSetting.savePrioritizeRecentGalleryGroups,
+    );
   }
 
   Widget _buildDownloadConcurrency() {

--- a/lib/src/service/gallery_download_service.dart
+++ b/lib/src/service/gallery_download_service.dart
@@ -898,10 +898,7 @@ class GalleryDownloadService extends GetxController with GridBasePageServiceMixi
         return aOrder - bOrder;
       }
 
-      DateTime aTime = DateFormat('yyyy-MM-dd HH:mm:ss').parse(a.insertTime);
-      DateTime bTime = DateFormat('yyyy-MM-dd HH:mm:ss').parse(b.insertTime);
-
-      return bTime.difference(aTime).inMilliseconds;
+      return b.insertTime.compareTo(a.insertTime);
     });
   }
 

--- a/lib/src/setting/download_setting.dart
+++ b/lib/src/setting/download_setting.dart
@@ -19,6 +19,7 @@ class DownloadSetting with JHLifeCircleBeanWithConfigStorage implements JHLifeCi
   RxBool downloadOriginalImageByDefault = false.obs;
   RxnString defaultGalleryGroup = RxnString();
   RxnString defaultArchiveGroup = RxnString();
+  List<String> recentGalleryGroups = [];
   late String defaultExtraGalleryScanPath;
   late RxList<String> extraGalleryScanPath;
   late RxString singleImageSavePath;
@@ -51,6 +52,9 @@ class DownloadSetting with JHLifeCircleBeanWithConfigStorage implements JHLifeCi
     downloadOriginalImageByDefault.value = map['downloadOriginalImageByDefault'] ?? downloadOriginalImageByDefault.value;
     defaultGalleryGroup.value = map['defaultGalleryGroup'];
     defaultArchiveGroup.value = map['defaultArchiveGroup'];
+    if (map['recentGalleryGroups'] != null) {
+      recentGalleryGroups = map['recentGalleryGroups'].cast<String>();
+    }
     downloadTaskConcurrency.value = map['downloadTaskConcurrency'];
     maximum.value = map['maximum'];
     period.value = Duration(milliseconds: map['period']);
@@ -74,6 +78,7 @@ class DownloadSetting with JHLifeCircleBeanWithConfigStorage implements JHLifeCi
       'downloadOriginalImageByDefault': downloadOriginalImageByDefault.value,
       'defaultGalleryGroup': defaultGalleryGroup.value,
       'defaultArchiveGroup': defaultArchiveGroup.value,
+      'recentGalleryGroups': recentGalleryGroups,
       'downloadTaskConcurrency': downloadTaskConcurrency.value,
       'maximum': maximum.value,
       'period': period.value.inMilliseconds,
@@ -141,6 +146,12 @@ class DownloadSetting with JHLifeCircleBeanWithConfigStorage implements JHLifeCi
   Future<void> saveDefaultArchiveGroup(String? group) async {
     log.debug('saveDefaultArchiveGroup:$group');
     this.defaultArchiveGroup.value = group;
+    await saveBeanConfig();
+  }
+
+  Future<void> saveRecentGalleryGroup(String group) async {
+    recentGalleryGroups.removeWhere((candidate) => candidate == group);
+    recentGalleryGroups.insert(0, group);
     await saveBeanConfig();
   }
 

--- a/lib/src/setting/download_setting.dart
+++ b/lib/src/setting/download_setting.dart
@@ -19,6 +19,7 @@ class DownloadSetting with JHLifeCircleBeanWithConfigStorage implements JHLifeCi
   RxBool downloadOriginalImageByDefault = false.obs;
   RxnString defaultGalleryGroup = RxnString();
   RxnString defaultArchiveGroup = RxnString();
+  RxBool prioritizeRecentGalleryGroups = true.obs;
   List<String> recentGalleryGroups = [];
   late String defaultExtraGalleryScanPath;
   late RxList<String> extraGalleryScanPath;
@@ -52,6 +53,7 @@ class DownloadSetting with JHLifeCircleBeanWithConfigStorage implements JHLifeCi
     downloadOriginalImageByDefault.value = map['downloadOriginalImageByDefault'] ?? downloadOriginalImageByDefault.value;
     defaultGalleryGroup.value = map['defaultGalleryGroup'];
     defaultArchiveGroup.value = map['defaultArchiveGroup'];
+    prioritizeRecentGalleryGroups.value = map['prioritizeRecentGalleryGroups'] ?? prioritizeRecentGalleryGroups.value;
     if (map['recentGalleryGroups'] != null) {
       recentGalleryGroups = map['recentGalleryGroups'].cast<String>();
     }
@@ -78,6 +80,7 @@ class DownloadSetting with JHLifeCircleBeanWithConfigStorage implements JHLifeCi
       'downloadOriginalImageByDefault': downloadOriginalImageByDefault.value,
       'defaultGalleryGroup': defaultGalleryGroup.value,
       'defaultArchiveGroup': defaultArchiveGroup.value,
+      'prioritizeRecentGalleryGroups': prioritizeRecentGalleryGroups.value,
       'recentGalleryGroups': recentGalleryGroups,
       'downloadTaskConcurrency': downloadTaskConcurrency.value,
       'maximum': maximum.value,
@@ -149,7 +152,19 @@ class DownloadSetting with JHLifeCircleBeanWithConfigStorage implements JHLifeCi
     await saveBeanConfig();
   }
 
+  Future<void> savePrioritizeRecentGalleryGroups(bool value) async {
+    log.debug('savePrioritizeRecentGalleryGroups:$value');
+    prioritizeRecentGalleryGroups.value = value;
+    await saveBeanConfig();
+  }
+
+  List<String> get preferredGalleryGroups => prioritizeRecentGalleryGroups.isTrue ? recentGalleryGroups : const [];
+
   Future<void> saveRecentGalleryGroup(String group) async {
+    log.debug('saveRecentGalleryGroup:$group');
+    if (prioritizeRecentGalleryGroups.isFalse) {
+      return;
+    }
     recentGalleryGroups.removeWhere((candidate) => candidate == group);
     recentGalleryGroups.insert(0, group);
     await saveBeanConfig();

--- a/lib/src/widget/eh_download_dialog.dart
+++ b/lib/src/widget/eh_download_dialog.dart
@@ -13,6 +13,7 @@ class EHDownloadDialog extends StatefulWidget {
   final List<String> candidates;
   final bool showDownloadOriginalImageCheckBox;
   final bool downloadOriginalImage;
+  final List<String> preferredGroups;
 
   const EHDownloadDialog({
     Key? key,
@@ -21,6 +22,7 @@ class EHDownloadDialog extends StatefulWidget {
     required this.candidates,
     this.showDownloadOriginalImageCheckBox = false,
     this.downloadOriginalImage = false,
+    this.preferredGroups = const [],
   }) : super(key: key);
 
   @override
@@ -37,9 +39,8 @@ class _EHDownloadDialogState extends State<EHDownloadDialog> {
     super.initState();
 
     group = widget.currentGroup ?? widget.candidates.firstOrNull ?? 'default'.tr;
-    candidates = List.of(widget.candidates);
-    candidates.remove(group);
-    candidates.insert(0, group);
+    final validGroups = widget.candidates.toSet();
+    candidates = <String>{...widget.preferredGroups.where(validGroups.contains), group, ...widget.candidates}.toList();
     downloadOriginalImage = widget.downloadOriginalImage;
   }
 

--- a/test/download_setting_test.dart
+++ b/test/download_setting_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jhentai/src/setting/download_setting.dart';
+
+void main() {
+  test('recent gallery groups can be disabled', () {
+    DownloadSetting setting = DownloadSetting();
+    setting.recentGalleryGroups = ['recent', 'older'];
+
+    expect(setting.preferredGalleryGroups, ['recent', 'older']);
+
+    setting.prioritizeRecentGalleryGroups.value = false;
+    expect(setting.preferredGalleryGroups, isEmpty);
+  });
+}


### PR DESCRIPTION
## 问题

1. 下载时分组只显示在一行横向列表中。当分组较多时，如果经常使用的分组位置靠后，连续下载需要反复查找和滚动，操作比较麻烦。
2. 下载总任务数多时，确认下载出现明显卡顿。


## 修改

1. 下载时分组标签按最近使用优先排序。
2. 下载任务的 `insertTime` 由 `DateTime.now().toString()` 生成，其字符串顺序与实际时间顺序一致。因此将原来的 `DateTime` 解析比较改为直接比较字符串，避免大量重复解析，解决任务数量多时确认下载的卡顿。