### PR TITLE
feat: add opt-in Apple visual style

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ JHenTai is a Flutter app for browsing E-Hentai / EXHentai, targeting Android, iO
 flutter pub get
 
 # Run code generation (Drift DB, etc.) — required after editing any @DriftDatabase tables/queries
-dart run build_runner build
+dart run build_runner build --delete-conflicting-outputs
 
 # Run code generation in watch mode during active DB work
 dart run build_runner watch --delete-conflicting-outputs
@@ -24,118 +24,119 @@ flutter run
 # Lint
 flutter analyze
 
-# Run tests
-flutter test
+# Run tests (single file, or a single test by name)
+flutter test test/download_setting_test.dart
+flutter test --plain-name 'recent gallery groups can be disabled'
 ```
 
-No test directory files are present, so `flutter test` is purely for when new tests are added.
+`test/` currently contains one real test (`test/download_setting_test.dart`, covering `DownloadSetting`); add new tests there. Release artifacts are built by the platform scripts at the repo root (`apk.sh`, `ipa.sh`, `dmg.sh`, `pkg.sh`, `windows.sh`, `linux.sh`, `thin-payload.sh`) — each reads the version from `pubspec.yaml` and builds with `-t lib/src/main.dart`.
 
 ## Architecture
 
 ### Dependency framework: GetX
-State management, routing, dependency injection, and i18n all use GetX. Widgets use `GetBuilder<T>` (manual `update()`), not reactive `.obs` streams. Pages use `.obs` for settings that must broadcast changes across views.
+
+State management, routing, dependency injection, and i18n all use GetX. Page state is driven by `GetBuilder<T>` with manual `update([ids])` — controllers commonly call the `updateSafely([...])` extension from `lib/src/extension/get_logic_extension.dart`. Reactive `.obs` fields (122 of them) live on the setting singletons in `lib/src/setting/`, never on page controllers; pages consume them via `Obx` for cross-view rebuilds, and logic layers react to them with `ever`/`everAll` Workers. The auto-listening `GetX<T>` widget is never used.
 
 ### Lifecycle: `JHLifeCircleBean` pattern
 
-Every singleton service and setting implements `JHLifeCircleBean` from `lib/src/service/jh_service.dart`:
+Every singleton service, setting, and the network singletons (`ehRequest`, `jhRequest`, `archiveBotRequest`) implement `JHLifeCircleBean` from `lib/src/service/jh_service.dart`:
 
 - `initBean()` — async init (called before `runApp`)
-- `afterBeanReady()` — post-runApp setup
+- `afterBeanReady()` — post-runApp setup (called from `GetMaterialApp.onReady`, not awaited)
 - `initDependencies` — list of other beans this one needs initialized first
 
-All beans are registered in a topological-sorted list in `lib/src/main.dart` and initialized in order. **Adding a new service/setting requires inserting it into this list with the correct `initDependencies` ordering** — out-of-order registration will cause init failures. Three mixins simplify common patterns:
-- `JHLifeCircleBeanErrorCatch` — wraps init/ready in try/catch with logging; subclasses override `doInitBean()` / `doAfterBeanReady()` instead
-- `JHLifeCircleBeanWithConfigStorage` — adds JSON serialize/deserialize to the `local_config` DB table via `applyBeanConfig()` / `getBeanConfig()`
-- Service beans live in `lib/src/service/`; settings singletons live in `lib/src/setting/`
+All beans are registered in the `lifeCircleBeans` list in `lib/src/main.dart`. `main()` runs `topologicalSort()` at runtime, which reorders the list purely from each bean's `initDependencies`, so **the literal order of the list does not matter** — only the dependency graph does. A circular dependency throws an uncaught `Exception` and aborts startup; a single bean's init failure is caught and logged by the mixins and is not fatal. To add a bean: add it to the list and declare correct `initDependencies` (avoiding cycles). Two mixins simplify common patterns:
+
+- `JHLifeCircleBeanErrorCatch` — wraps init/ready in try/catch with logging; subclasses override `doInitBean()` / `doAfterBeanReady()`; defaults `initDependencies` to `[pathService, log]`
+- `JHLifeCircleBeanWithConfigStorage` — adds config persistence to the `local_config` DB table via `LocalConfigService`; beans override `applyBeanConfig(String)` and `toConfigString()` (JSON in practice) and save with `saveBeanConfig()`; defaults `initDependencies` to `[pathService, log, localConfigService]`
+
+Service beans live in `lib/src/service/`; settings singletons live in `lib/src/setting/`.
 
 ### Logging
 
-Uses the `logger` package via the global `log` singleton (`lib/src/service/log.dart`). Four tiered outputs:
-- Console logger (dev: colored + method info; prod: plain with timestamp)
-- Verbose file logger (trace-level, `verbose/`)
-- Warning file logger (warn+, `warning/`)
-- Download-specific file logger (`download/`)
-
-Call `log.trace/debug/info/warn/error(msg, e, stack)`. Errors in `JHLifeCircleBeanErrorCatch` mixin are automatically logged.
+Uses the `logger` package via the global `log` singleton (`lib/src/service/log.dart`). A console logger receives every tier. File loggers write into a single `logs/` directory under `pathService.getVisibleDir()`, one timestamped file set per session: a trace-level verbose file (`{timestamp}.log`) always, plus — only when the `enableVerboseLogging` Advanced setting is on (default in debug builds) — a warning file (`{timestamp}_error.log`) and a download file (`{timestamp}_download.log`). Call `log.trace/debug/info(msg, [withStack])`, `log.warning(msg, [error, withStack])`, `log.error(msg, [error, stackTrace])`, `log.download(msg)`. Errors in the `JHLifeCircleBeanErrorCatch` mixin and the global `FlutterError` / `PlatformDispatcher` handlers are logged automatically. Logs are not auto-rotated; `log.clear()` (from the Advanced settings page) wipes the directory.
 
 ### Supporting directories
 
-- `lib/src/config/` — app-level configuration (theme, UI constants, Sentry, API secrets)
-- `lib/src/enum/` — enums shared across the app (`EHNamespace`, `ConfigEnum`, `ConfigTypeEnum`)
+- `lib/src/config/` — app-level configuration (theme, UI constants, API secrets)
+- `lib/src/consts/` — constants per backend (`eh_consts`, `jh_consts`, `archive_bot_consts`, `locale_consts`)
+- `lib/src/enum/` — enums shared across the app (`EHNamespace`, `ConfigEnum`, `CloudConfigTypeEnum`)
 - `lib/src/extension/` — extension methods on framework types (DioException, String, List, Directory, Widget, GetLogic)
-- `lib/src/mixin/` — reusable page mixins: scroll-to-top, double-tap-refresh, login-required guard, animation, window-widget
+- `lib/src/mixin/` — reusable page mixins: scroll-to-top, double-tap-refresh, login-required guard, animation, window-widget, global-gallery-status
 - `lib/src/model/` — data classes: `Gallery`, `GalleryTag`, `GalleryImage`, `GalleryComment`, `SearchConfig`, `SearchHistory`, and per-endpoint response models in `model/jh_response/` and `model/archive_bot_response/`
-- `lib/src/utils/` — 30+ utility files for parsing (eh_spider_parser, jh_spider_parser), IO, date, crypto, proxy, version, etc.
-- `lib/src/exception/` — custom exception classes (`EHSiteException`, `NotUploadException`)
+- `lib/src/utils/` — ~30 utility files for parsing (`eh_spider_parser`, `jh_spider_parser`), IO, date, crypto, proxy, version, etc.
+- `lib/src/exception/` — custom exception classes (`EHSiteException`, `NotUploadException`, and several others)
 
 ### Routing
 
-All routes are defined in `lib/src/routes/routes.dart` as static const strings on `class Routes`. The `EHPage` class extends `GetPage` and adds:
-- `side` — `left`/`right`/`fullScreen` (tablet layout uses left/right split)
+All routes are defined in `lib/src/routes/routes.dart` as static const strings on `class Routes`, together with the `static List<EHPage> pages` map and `defaultTransition`. The `EHPage` class extends `GetPage` and adds:
+- `side` — `left`/`right`/`fullScreen` (which navigator the route pushes to, in the tablet and desktop split layouts)
 - `offAllBefore` — whether previous right-side routes are popped
 
-Nested settings routes use a `settingPrefix` convention (`/setting_*`).
+Actual navigation goes through `toRoute()` in `lib/src/utils/route_util.dart`, which adapts the push to the current layout. Nested settings routes use a `settingPrefix` convention (`/setting_*`). `GetXRouterObserver` (`lib/src/routes/getx_router_observer.dart`) keeps GetX controllers recycled when the native Navigator API is used.
 
 ### Page pattern
 
 Pages follow a consistent GetX structure in `lib/src/pages/`:
-
 - `*_page.dart` — Widget
-- `*_logic.dart` — `GetxController` subclass (business logic)
-- `*_state.dart` — Mutable state object
+- `*_page_logic.dart` — `GetxController` subclass (business logic)
+- `*_page_state.dart` — Mutable state object
 
-The base class is `BasePageLogic` (`pages/base/base_page_logic.dart`) which handles gallery-list pages: pull-to-refresh, pagination (prev/next gid), search config persistence, and tag blocking/filtering. Subclasses override `getGalleryPage()` to provide page-specific API calls.
+Gallery-list pages inherit the base trio in `pages/base/`: `BasePage` (widget), `BasePageLogic` (`GetxController`), `BasePageState` (state). `BasePageLogic` handles pull-to-refresh, pagination (prev/next gid), search config persistence, and tag blocking/filtering. Subclasses configure it through getters like `useSearchConfig` / `autoLoadNeedLogin`; `getGalleryPage()` is an override hook whose default implementation already performs the API call. `OldBasePageLogic`/`OldBasePageState` implement page-index-based pagination for EH's old search rule. The details/read pages are **not** `BasePageLogic` subclasses — they use the same file convention but extend `GetxController` directly.
 
 ### Network layer (`lib/src/network/`)
 
 Uses a custom Dio fork (`dio` from `jiangtian616/dio` at `append-mode` ref). Main request classes:
-- `EHRequest` — all E-Hentai API calls, with cookie management, caching, domain fronting for EX
-- `JHRequest` — backend API calls (tag translations, app update checks, built-in block lists)
-- `ArchiveBotRequest` — archive.org resolution
+- `EHRequest` — the workhorse for all E-Hentai and app-managed HTTP: E-Hentai API calls with cookie management (`eh_cookie_manager`), custom SQLite caching (`eh_cache_manager` over the `dio_cache` table), and domain fronting for EX (`eh_ip_provider`); also fetches tag translations (EhTagTranslation via jsdelivr), GitHub release/update data, and the built-in block list
+- `JHRequest` — JHenTai backend API calls (cloud config sync, signed image-hash endpoint)
+- `ArchiveBotRequest` — archive.org resolution (EhArBot / Archive-at-Home protocols)
 
-Parsers for HTML responses live in `lib/src/utils/eh_spider_parser.dart`.
+`EHRequest` / `JHRequest` / `ArchiveBotRequest` are themselves `JHLifeCircleBean`s. Parsers for HTML responses live in `lib/src/utils/eh_spider_parser.dart`.
 
 ### Database (`lib/src/database/`)
 
-Drift (SQLite) at schema version 24 with heavy migration chain. Tables in `database/table/`, DAOs in `database/dao/`. The global `appDb` singleton is declared at the bottom of `database.dart`. Generated code is in `database.g.dart` — re-run `dart run build_runner build` after any schema change and add a migration step in `MigrationStrategy.onUpgrade`.
+Drift (SQLite) at schema version 24 with a heavy migration chain. Tables in `database/table/`, hand-written DAOs (static methods over `appDb`) in `database/dao/`. Current physical tables are `_v2`-suffixed (`gallery_downloaded_v2`, `archive_downloaded_v2`, `super_resolution_info_v2`, `gallery_history_v2`); the unsuffixed tables are legacy/migration variants. The global `appDb` singleton is declared at the bottom of `database.dart`. Generated code is in `database.g.dart` — re-run `dart run build_runner build` after any schema change and add a migration step in `MigrationStrategy.onUpgrade` (the chain also runs one-off data backfills, and migration errors rethrow `NotUploadException`).
 
 ### Services (`lib/src/service/`)
 
 Independent singletons that manage core features:
-- `gallery_download_service.dart` / `archive_download_service.dart` — download engine with parallel queue, resume, priority
-- `tag_translation_service.dart` — fetches and caches tag translations from EhTagTranslation
-- `local_block_rule_service.dart` — user-configured gallery blocking rules
-- `cloud_service.dart` — config sync
-- `storage_service.dart` — JSON/GetStorage NoSQL persistence
-- `super_resolution_service.dart` — image upscaling metadata tracking
+- `gallery_download_service.dart` / `archive_download_service.dart` — download engines with parallel queue, resume, priority
+- `local_config_service.dart` — the DB-backed KV store all settings persist through (backbone of `JHLifeCircleBeanWithConfigStorage`)
+- `app_update_service.dart` — versioned migration engine (runs 11 update handlers from a version stamp, migrating legacy settings into `local_config`)
+- `schedule_service.dart` — post-launch scheduled tasks (update check, tag refresh, cache cleanup, EH event polling, ArchiveBot check-in)
+- `tag_translation_service.dart` — fetches/caches EhTagTranslation, tag autocomplete
+- `local_block_rule_service.dart` — user-configured gallery & comment blocking rules (23 rule handlers + pluggable providers)
+- `built_in_blocked_user_service.dart` — downloads/contributes the built-in blocked-user list
+- `super_resolution_service.dart` — full upscaling engine (model download, external process, status tracking)
+- `cloud_service.dart` — cloud-config sync payload serialization (the remote transfer lives in the config-sync page)
+- `storage_service.dart` — GetStorage NoSQL persistence (now largely legacy/backward-compat since v8.x)
+- `isolate_service.dart` — off-main-isolate JSON/compute helpers
 - `path_service.dart` — platform-aware directory resolution
 
 ### Settings (`lib/src/setting/`)
 
-Each setting module is a standalone singleton (e.g., `ehSetting`, `styleSetting`, `preferenceSetting`) using `JHLifeCircleBeanWithConfigStorage`. Settings are serialized as JSON and stored in the `local_config` DB table. Reactive `.obs` values are used when settings need to trigger UI rebuilds across the app.
+Each setting module is a standalone singleton (e.g., `ehSetting`, `styleSetting`, `preferenceSetting`) using `JHLifeCircleBeanWithConfigStorage` — the one exception is `my_tags_setting.dart`, which holds server-session data and uses `JHLifeCircleBeanErrorCatch`. Settings are serialized as JSON and stored in the `local_config` DB table. Reactive `.obs` values are used when settings need to trigger UI rebuilds across the app.
 
 ### Layout system (`lib/src/pages/layout/`)
 
-Three layout modes:
-- `mobile_v2` — bottom navigation bar with tab-style pages
-- `tablet_v2` — master-detail split (left/right route sides)
-- `desktop` — sidebar navigation with persistent detail panel
-
-The home page (`home_page.dart`) selects the layout based on screen width.
+Three layout modes, selected in `home_page.dart` primarily from the user's `styleSetting.layout` preference: `mobile_v2` (bottom navigation bar with tab-style pages), `tablet_v2` (master-detail split with left/right route sides), `desktop` (sidebar icon tab bar + persistent detail panel). Screen width only overrides to mobile when `Get.width < 600`; the initial default is auto-picked by device width in `style_setting.dart`. Tablet and desktop both use a resizable split via `flutter_resizable_container`.
 
 ### i18n (`lib/src/l18n/`)
 
-Custom translation system via `LocaleText` (GetX `Translations`). One `.dart` file per language with key-value pairs. Adding a new language requires: the locale file, an entry in `locale_text.dart`, and an entry in `locale_consts.dart`.
+Custom translation system via `LocaleText` (GetX `Translations`). One `.dart` file per language (`en_US`, `zh_CN`, `zh_TW`, `ko_KR`, `pt_BR`, `ru_RU`) with key-value pairs. Adding a new language requires: the locale file in `l18n/`, an entry in `locale_text.dart`, an entry in `localeCode2Description` in `lib/src/consts/locale_consts.dart` (the language-picker dropdown looks it up with a null-assert, so the two files must stay in sync), **and** an entry in `supportedLocales` in `lib/src/main.dart`. (`ru_RU` currently demonstrates what happens when the last step is skipped — it is registered but missing from `supportedLocales`.)
 
 ### Widget library (`lib/src/widget/`)
 
-Reusable widgets prefixed `eh_` — dialogs, cards, image components, tag displays, etc. The `app_manager.dart` widget wraps the entire app for global concerns. The `loading_state_indicator.dart` provides a standard loading/error/empty/idle state widget.
+Reusable widgets prefixed `eh_` — dialogs, cards, image components, tag displays, etc. The `app_manager.dart` widget wraps the entire app for global concerns (app lifecycle, platform-brightness theme switching, privacy: background blur + Android FLAG_SECURE, lock-screen on resume). The `loading_state_indicator.dart` provides a standard loading/error/empty/idle state widget.
 
 ### Key dependencies (beyond Flutter standard)
 
-- `get` 4.6.6 — state management, routing, i18n, NoSQL storage
-- `dio` (custom fork) — HTTP client
+- `get` 4.6.6 — state management, routing, i18n
+- `dio` (custom `jiangtian616/dio` fork) — HTTP client
 - `drift` 2.21.0 — SQLite ORM
 - `extended_image` — image loading with cache
-- `photo_view` / `zoom_view` (custom forks) — reading page image viewer
+- `photo_view` / `zoom_view` (custom `jiangtian616` forks) — reading page image viewer
+- `get_storage` — NoSQL persistence (used by `storage_service`)
 - `desktop_webview_window` — desktop webview for cookie login
+
+Many other dependencies are also `jiangtian616` forks (e.g. `scrollable_positioned_list`, `like_button`, `j_downloader`, proxy packages); `j_downloader` powers the archive download engine.

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '13.0'
+platform :ios, '15.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -39,6 +39,7 @@ post_install do |installer|
     flutter_additional_ios_build_settings(target)
     # Start of the permission_handler configuration
     target.build_configurations.each do |config|
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '15.0'
       config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
         '$(inherited)',
         # 'PERMISSION_EVENTS=1',

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,10 +1,6 @@
 PODS:
   - audio_session (0.0.1):
     - Flutter
-  - battery_plus (1.0.0):
-    - Flutter
-  - device_info_plus (0.0.1):
-    - Flutter
   - DKImagePickerController/Core (4.3.9):
     - DKImagePickerController/ImageDataManager
     - DKImagePickerController/Resource
@@ -47,16 +43,8 @@ PODS:
     - Flutter
   - just_audio (0.0.1):
     - Flutter
-  - local_auth_darwin (0.0.1):
-    - Flutter
-    - FlutterMacOS
   - package_info_plus (0.4.5):
     - Flutter
-  - pasteboard (0.0.1):
-    - Flutter
-  - path_provider_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
   - permission_handler_apple (9.3.0):
     - Flutter
   - receive_sharing_intent (1.8.1):
@@ -68,96 +56,45 @@ PODS:
   - SDWebImage (5.21.7):
     - SDWebImage/Core (= 5.21.7)
   - SDWebImage/Core (5.21.7)
-  - share_plus (0.0.1):
-    - Flutter
   - smart_auth (0.0.1):
     - Flutter
-  - sqflite_darwin (0.0.4):
-    - Flutter
-    - FlutterMacOS
-  - sqlite3 (3.49.2):
-    - sqlite3/common (= 3.49.2)
-  - sqlite3/common (3.49.2)
-  - sqlite3/dbstatvtab (3.49.2):
-    - sqlite3/common
-  - sqlite3/fts5 (3.49.2):
-    - sqlite3/common
-  - sqlite3/math (3.49.2):
-    - sqlite3/common
-  - sqlite3/perf-threadsafe (3.49.2):
-    - sqlite3/common
-  - sqlite3/rtree (3.49.2):
-    - sqlite3/common
-  - sqlite3_flutter_libs (0.0.1):
-    - Flutter
-    - FlutterMacOS
-    - sqlite3 (~> 3.49.1)
-    - sqlite3/dbstatvtab
-    - sqlite3/fts5
-    - sqlite3/math
-    - sqlite3/perf-threadsafe
-    - sqlite3/rtree
   - SwiftyGif (5.4.5)
   - system_network_proxy (0.0.1):
     - Flutter
   - Toast (4.1.1)
-  - url_launcher_ios (0.0.1):
-    - Flutter
-  - video_player_avfoundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - volume_key_board (0.0.1):
+  - volume_button_override (0.0.1):
     - Flutter
   - wakelock_plus (0.0.1):
     - Flutter
-  - webview_flutter_wkwebview (0.0.1):
-    - Flutter
-    - FlutterMacOS
 
 DEPENDENCIES:
   - audio_session (from `.symlinks/plugins/audio_session/ios`)
-  - battery_plus (from `.symlinks/plugins/battery_plus/ios`)
-  - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - file_picker (from `.symlinks/plugins/file_picker/ios`)
   - Flutter (from `Flutter`)
   - fluttertoast (from `.symlinks/plugins/fluttertoast/ios`)
   - http_proxy (from `.symlinks/plugins/http_proxy/ios`)
   - just_audio (from `.symlinks/plugins/just_audio/ios`)
-  - local_auth_darwin (from `.symlinks/plugins/local_auth_darwin/darwin`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
-  - pasteboard (from `.symlinks/plugins/pasteboard/ios`)
-  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - receive_sharing_intent (from `.symlinks/plugins/receive_sharing_intent/ios`)
   - saver_gallery (from `.symlinks/plugins/saver_gallery/ios`)
   - screen_brightness_ios (from `.symlinks/plugins/screen_brightness_ios/ios`)
-  - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - smart_auth (from `.symlinks/plugins/smart_auth/ios`)
-  - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
-  - sqlite3_flutter_libs (from `.symlinks/plugins/sqlite3_flutter_libs/darwin`)
   - system_network_proxy (from `.symlinks/plugins/system_network_proxy/ios`)
-  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
-  - video_player_avfoundation (from `.symlinks/plugins/video_player_avfoundation/darwin`)
-  - volume_key_board (from `.symlinks/plugins/volume_key_board/ios`)
+  - volume_button_override (from `.symlinks/plugins/volume_button_override/ios`)
   - wakelock_plus (from `.symlinks/plugins/wakelock_plus/ios`)
-  - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/darwin`)
 
 SPEC REPOS:
   trunk:
     - DKImagePickerController
     - DKPhotoGallery
     - SDWebImage
-    - sqlite3
     - SwiftyGif
     - Toast
 
 EXTERNAL SOURCES:
   audio_session:
     :path: ".symlinks/plugins/audio_session/ios"
-  battery_plus:
-    :path: ".symlinks/plugins/battery_plus/ios"
-  device_info_plus:
-    :path: ".symlinks/plugins/device_info_plus/ios"
   file_picker:
     :path: ".symlinks/plugins/file_picker/ios"
   Flutter:
@@ -168,14 +105,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/http_proxy/ios"
   just_audio:
     :path: ".symlinks/plugins/just_audio/ios"
-  local_auth_darwin:
-    :path: ".symlinks/plugins/local_auth_darwin/darwin"
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
-  pasteboard:
-    :path: ".symlinks/plugins/pasteboard/ios"
-  path_provider_foundation:
-    :path: ".symlinks/plugins/path_provider_foundation/darwin"
   permission_handler_apple:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
   receive_sharing_intent:
@@ -184,61 +115,37 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/saver_gallery/ios"
   screen_brightness_ios:
     :path: ".symlinks/plugins/screen_brightness_ios/ios"
-  share_plus:
-    :path: ".symlinks/plugins/share_plus/ios"
   smart_auth:
     :path: ".symlinks/plugins/smart_auth/ios"
-  sqflite_darwin:
-    :path: ".symlinks/plugins/sqflite_darwin/darwin"
-  sqlite3_flutter_libs:
-    :path: ".symlinks/plugins/sqlite3_flutter_libs/darwin"
   system_network_proxy:
     :path: ".symlinks/plugins/system_network_proxy/ios"
-  url_launcher_ios:
-    :path: ".symlinks/plugins/url_launcher_ios/ios"
-  video_player_avfoundation:
-    :path: ".symlinks/plugins/video_player_avfoundation/darwin"
-  volume_key_board:
-    :path: ".symlinks/plugins/volume_key_board/ios"
+  volume_button_override:
+    :path: ".symlinks/plugins/volume_button_override/ios"
   wakelock_plus:
     :path: ".symlinks/plugins/wakelock_plus/ios"
-  webview_flutter_wkwebview:
-    :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 SPEC CHECKSUMS:
-  audio_session: 088d2483ebd1dc43f51d253d4a1c517d9a2e7207
-  battery_plus: 34f72fa2afeeea83bbae306c72a25828d3ec727a
-  device_info_plus: bf2e3232933866d73fe290f2942f2156cdd10342
+  audio_session: f08db0697111ac84ba46191b55488c0563bb29c6
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
-  file_picker: 09aa5ec1ab24135ccd7a1621c46c84134bfd6655
-  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  fluttertoast: e9a18c7be5413da53898f660530c56f35edfba9c
-  http_proxy: 20f129d3e1c70cfdef92530b374c619832027729
-  just_audio: baa7252489dbcf47a4c7cc9ca663e9661c99aafa
-  local_auth_darwin: 66e40372f1c29f383a314c738c7446e2f7fdadc3
-  package_info_plus: 58f0028419748fad15bf008b270aaa8e54380b1c
-  pasteboard: bfa22da3a15aff2c2cd3d5d17bc595439b172895
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
-  receive_sharing_intent: 79c848f5b045674ad60b9fea3bafea59962ad2c1
-  saver_gallery: 76172dc4bf6b40e66d694948ada9ff402304dd87
-  screen_brightness_ios: 715ca807df953bf676d339f11464e438143ee625
+  file_picker: 9b3292d7c8bc68c8a7bf8eb78f730e49c8efc517
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  fluttertoast: 76fea30fcf04176325f6864c87306927bd7d2038
+  http_proxy: 6e9876b8b0d8bd9378a526bf49c51d8df64e891e
+  just_audio: 6c031bb61297cf218b4462be616638e81c058e97
+  package_info_plus: 580e9a5f1b6ca5594e7c9ed5f92d1dfb2a66b5e1
+  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
+  receive_sharing_intent: 222384f00ffe7e952bbfabaa9e3967cb87e5fe00
+  saver_gallery: af2d0c762dafda254e0ad025ef0dabd6506cd490
+  screen_brightness_ios: 5ed898fa50fa82a26171c086ca5e28228f932576
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
-  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
-  smart_auth: 4bedbc118723912d0e45a07e8ab34039c19e04f2
-  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
-  sqlite3: 3c950dc86011117c307eb0b28c4a7bb449dce9f1
-  sqlite3_flutter_libs: 487032b9008b28de37c72a3aa66849ef3745f3e6
+  smart_auth: 33668081c5f646af84f10492a067d25fdcd16951
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
-  system_network_proxy: 6f63fddb34a28776f091b1221a17850170c59e01
+  system_network_proxy: c0b2ba3a6d877b4861e22300ecfb60df4d200382
   Toast: 1f5ea13423a1e6674c4abdac5be53587ae481c4e
-  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
-  video_player_avfoundation: 7c6c11d8470e1675df7397027218274b6d2360b3
-  volume_key_board: 544501f83cce6478414091fb47f614471108b220
-  wakelock_plus: 78ec7c5b202cab7761af8e2b2b3d0671be6c4ae1
-  webview_flutter_wkwebview: 0982481e3d9c78fd5c6f62a002fcd24fc791f1e4
+  volume_button_override: 591c34d9d1542294e099948b4100dc5810721741
+  wakelock_plus: fd58c82b1388f4afe3fe8aa2c856503a262a5b03
 
-PODFILE CHECKSUM: 88c1fcf156b1724e87ab2235af25400ef2858b42
+PODFILE CHECKSUM: 04e4921de7678321752f3d655e2141b932b83f48
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.17.0

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -47,6 +48,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -54,6 +56,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
 				7EA4A4A01945BE028DC6B55D /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -64,6 +67,7 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
@@ -128,6 +132,9 @@
 
 /* Begin PBXNativeTarget section */
 		97C146ED1CF9000F007C117D /* Runner */ = {
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
@@ -154,6 +161,9 @@
 
 /* Begin PBXProject section */
 		97C146E61CF9000F007C117D /* Project object */ = {
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
+			);
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1510;
@@ -360,7 +370,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
@@ -379,7 +389,7 @@
 				DEVELOPMENT_TEAM = R5JAD5ZNYT;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -440,7 +450,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -489,7 +499,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
@@ -510,7 +520,7 @@
 				DEVELOPMENT_TEAM = R5JAD5ZNYT;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "Runner/Info-Debug.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -535,7 +545,7 @@
 				DEVELOPMENT_TEAM = R5JAD5ZNYT;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -573,6 +583,18 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+/* Begin XCLocalSwiftPackageReference section */
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCLocalSwiftPackageReference section */
+/* Begin XCSwiftPackageProductDependency section */
+		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 97C146E61CF9000F007C117D /* Project object */;
 }

--- a/lib/src/config/theme_config.dart
+++ b/lib/src/config/theme_config.dart
@@ -1,10 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 
 class ThemeConfig {
   /// Since Flutter 3.35, Material buttons default to the basic arrow cursor on desktop; restore the hand cursor.
   static const WidgetStatePropertyAll<MouseCursor> clickableMouseCursor = WidgetStatePropertyAll(WidgetStateMouseCursor.clickable);
 
+  /// Apple platforms (iOS / macOS) get the native Apple look; everything else keeps Material 3.
+  static bool get isApple => GetPlatform.isIOS || GetPlatform.isMacOS;
+
   static ThemeData theme(Color color, Brightness brightness) {
+    if (isApple) {
+      return _buildAppleTheme(brightness);
+    }
+    return _buildMaterialTheme(color, brightness);
+  }
+
+  static ThemeData _buildMaterialTheme(Color color, Brightness brightness) {
     ThemeData themeData = ThemeData(
       useMaterial3: true,
       brightness: brightness,
@@ -34,6 +45,69 @@ class ThemeConfig {
     return themeData.copyWith(
       appBarTheme: themeData.appBarTheme.copyWith(backgroundColor: themeData.colorScheme.surface),
       dialogTheme: DialogThemeData(backgroundColor: themeData.colorScheme.surface),
+    );
+  }
+
+  /// macOS / iOS look: neutral gray surfaces, fixed SF accent, native controls.
+  static ThemeData _buildAppleTheme(Brightness brightness) {
+    final bool isDark = brightness == Brightness.dark;
+
+    final Color accent = isDark ? const Color(0xFF0A84FF) : const Color(0xFF007AFF); // SF Blue
+    final Color window = isDark ? const Color(0xFF1E1E1E) : const Color(0xFFF5F5F7); // macOS window / iOS grouped bg
+    final Color onSurface = isDark ? const Color(0xFFF5F5F7) : const Color(0xFF1D1D1F); // primary label
+    final Color secondary = isDark ? const Color(0xFF98989D) : const Color(0xFF6E6E73); // secondary label
+    final Color separator = isDark ? const Color(0xFF3A3A3C) : const Color(0xFFD2D2D7); // separators
+    final Color error = isDark ? const Color(0xFFFF453A) : const Color(0xFFFF3B30); // systemRed
+
+    final ColorScheme scheme = ColorScheme.fromSeed(seedColor: accent, brightness: brightness).copyWith(
+      primary: accent,
+      onPrimary: Colors.white,
+      primaryContainer: accent.withValues(alpha: 0.2),
+      onPrimaryContainer: onSurface,
+      secondaryContainer: accent.withValues(alpha: 0.12),
+      onSecondaryContainer: onSurface,
+      surface: window,
+      onSurface: onSurface,
+      onSurfaceVariant: secondary,
+      surfaceContainerHighest: isDark ? const Color(0xFF2A2A2C) : const Color(0xFFE5E5EA),
+      outline: separator,
+      error: error,
+    );
+
+    return ThemeData(
+      useMaterial3: true,
+      brightness: brightness,
+      colorScheme: scheme,
+      platform: GetPlatform.isMacOS ? TargetPlatform.macOS : TargetPlatform.iOS,
+      textTheme: const TextTheme(titleMedium: TextStyle(fontWeight: FontWeight.w400)),
+      appBarTheme: AppBarTheme(
+        backgroundColor: window,
+        scrolledUnderElevation: 0,
+        surfaceTintColor: Colors.transparent,
+      ),
+      navigationBarTheme: const NavigationBarThemeData(
+        height: 48,
+        surfaceTintColor: Colors.transparent,
+        labelBehavior: NavigationDestinationLabelBehavior.alwaysHide,
+      ),
+      popupMenuTheme: PopupMenuThemeData(surfaceTintColor: Colors.transparent, color: window),
+      dialogTheme: DialogThemeData(backgroundColor: window, surfaceTintColor: Colors.transparent),
+      textSelectionTheme: TextSelectionThemeData(
+        selectionColor: accent.withValues(alpha: 0.2),
+        cursorColor: accent,
+        selectionHandleColor: accent,
+      ),
+      dividerTheme: DividerThemeData(color: separator),
+      textButtonTheme: const TextButtonThemeData(style: ButtonStyle(mouseCursor: clickableMouseCursor)),
+      elevatedButtonTheme: const ElevatedButtonThemeData(style: ButtonStyle(mouseCursor: clickableMouseCursor)),
+      outlinedButtonTheme: const OutlinedButtonThemeData(style: ButtonStyle(mouseCursor: clickableMouseCursor)),
+      iconButtonTheme: const IconButtonThemeData(style: ButtonStyle(mouseCursor: clickableMouseCursor)),
+      listTileTheme: const ListTileThemeData(mouseCursor: clickableMouseCursor),
+      switchTheme: const SwitchThemeData(mouseCursor: clickableMouseCursor),
+      checkboxTheme: const CheckboxThemeData(mouseCursor: clickableMouseCursor),
+      radioTheme: const RadioThemeData(mouseCursor: clickableMouseCursor),
+      sliderTheme: const SliderThemeData(mouseCursor: clickableMouseCursor),
+      tabBarTheme: const TabBarThemeData(mouseCursor: clickableMouseCursor),
     );
   }
 }

--- a/lib/src/config/theme_config.dart
+++ b/lib/src/config/theme_config.dart
@@ -2,15 +2,21 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 class ThemeConfig {
-  /// Since Flutter 3.35, Material buttons default to the basic arrow cursor on desktop; restore the hand cursor.
-  static const WidgetStatePropertyAll<MouseCursor> clickableMouseCursor = WidgetStatePropertyAll(WidgetStateMouseCursor.clickable);
+  /// The Apple visual overhaul is opt-in, even on Apple platforms.
+  static bool appleVisualStyleEnabled = false;
 
-  /// Apple platforms (iOS / macOS) get the native Apple look; everything else keeps Material 3.
-  static bool get isApple => GetPlatform.isIOS || GetPlatform.isMacOS;
+  /// Since Flutter 3.35, Material buttons default to the basic arrow cursor on desktop; restore the hand cursor.
+  static const WidgetStatePropertyAll<MouseCursor> clickableMouseCursor =
+      WidgetStatePropertyAll(WidgetStateMouseCursor.clickable);
+
+  static bool get isApplePlatform => GetPlatform.isIOS || GetPlatform.isMacOS;
+
+  /// iOS/macOS only, and only after the user enables it in Style settings.
+  static bool get isApple => isApplePlatform && appleVisualStyleEnabled;
 
   static ThemeData theme(Color color, Brightness brightness) {
     if (isApple) {
-      return _buildAppleTheme(brightness);
+      return _buildAppleTheme(color, brightness);
     }
     return _buildMaterialTheme(color, brightness);
   }
@@ -22,18 +28,24 @@ class ThemeConfig {
       colorSchemeSeed: color,
 
       /// default w500 is not supported for chinese characters in some devices
-      textTheme: const TextTheme(titleMedium: TextStyle(fontWeight: FontWeight.w400)),
+      textTheme:
+          const TextTheme(titleMedium: TextStyle(fontWeight: FontWeight.w400)),
       appBarTheme: const AppBarTheme(scrolledUnderElevation: 0),
       navigationBarTheme: const NavigationBarThemeData(
         height: 48,
         surfaceTintColor: Colors.transparent,
         labelBehavior: NavigationDestinationLabelBehavior.alwaysHide,
       ),
-      popupMenuTheme: const PopupMenuThemeData(surfaceTintColor: Colors.transparent),
-      textButtonTheme: const TextButtonThemeData(style: ButtonStyle(mouseCursor: clickableMouseCursor)),
-      elevatedButtonTheme: const ElevatedButtonThemeData(style: ButtonStyle(mouseCursor: clickableMouseCursor)),
-      outlinedButtonTheme: const OutlinedButtonThemeData(style: ButtonStyle(mouseCursor: clickableMouseCursor)),
-      iconButtonTheme: const IconButtonThemeData(style: ButtonStyle(mouseCursor: clickableMouseCursor)),
+      popupMenuTheme:
+          const PopupMenuThemeData(surfaceTintColor: Colors.transparent),
+      textButtonTheme: const TextButtonThemeData(
+          style: ButtonStyle(mouseCursor: clickableMouseCursor)),
+      elevatedButtonTheme: const ElevatedButtonThemeData(
+          style: ButtonStyle(mouseCursor: clickableMouseCursor)),
+      outlinedButtonTheme: const OutlinedButtonThemeData(
+          style: ButtonStyle(mouseCursor: clickableMouseCursor)),
+      iconButtonTheme: const IconButtonThemeData(
+          style: ButtonStyle(mouseCursor: clickableMouseCursor)),
       listTileTheme: const ListTileThemeData(mouseCursor: clickableMouseCursor),
       switchTheme: const SwitchThemeData(mouseCursor: clickableMouseCursor),
       checkboxTheme: const CheckboxThemeData(mouseCursor: clickableMouseCursor),
@@ -43,23 +55,40 @@ class ThemeConfig {
     );
 
     return themeData.copyWith(
-      appBarTheme: themeData.appBarTheme.copyWith(backgroundColor: themeData.colorScheme.surface),
-      dialogTheme: DialogThemeData(backgroundColor: themeData.colorScheme.surface),
+      appBarTheme: themeData.appBarTheme
+          .copyWith(backgroundColor: themeData.colorScheme.surface),
+      dialogTheme:
+          DialogThemeData(backgroundColor: themeData.colorScheme.surface),
     );
   }
 
-  /// macOS / iOS look: neutral gray surfaces, fixed SF accent, native controls.
-  static ThemeData _buildAppleTheme(Brightness brightness) {
+  /// macOS / iOS look: neutral gray surfaces with a user-selectable accent.
+  static ThemeData _buildAppleTheme(Color accent, Brightness brightness) {
     final bool isDark = brightness == Brightness.dark;
 
-    final Color accent = isDark ? const Color(0xFF0A84FF) : const Color(0xFF007AFF); // SF Blue
-    final Color window = isDark ? const Color(0xFF1E1E1E) : const Color(0xFFF5F5F7); // macOS window / iOS grouped bg
-    final Color onSurface = isDark ? const Color(0xFFF5F5F7) : const Color(0xFF1D1D1F); // primary label
-    final Color secondary = isDark ? const Color(0xFF98989D) : const Color(0xFF6E6E73); // secondary label
-    final Color separator = isDark ? const Color(0xFF3A3A3C) : const Color(0xFFD2D2D7); // separators
-    final Color error = isDark ? const Color(0xFFFF453A) : const Color(0xFFFF3B30); // systemRed
+    final Color window = isDark
+        ? const Color(0xFF1E1E1E)
+        : const Color(0xFFF5F5F7); // macOS window / iOS grouped bg
+    final Color onSurface = isDark
+        ? const Color(0xFFF5F5F7)
+        : const Color(0xFF1D1D1F); // primary label
+    final Color secondary = isDark
+        ? const Color(0xFF98989D)
+        : const Color(0xFF6E6E73); // secondary label
+    final Color separator = isDark
+        ? const Color(0xFF3A3A3C)
+        : const Color(0xFFD2D2D7); // separators
+    final Color error =
+        isDark ? const Color(0xFFFF453A) : const Color(0xFFFF3B30); // systemRed
+    final BorderRadius controlRadius = BorderRadius.circular(7);
+    final OutlineInputBorder inputBorder = OutlineInputBorder(
+      borderRadius: controlRadius,
+      borderSide: BorderSide(color: separator.withValues(alpha: 0.85)),
+    );
 
-    final ColorScheme scheme = ColorScheme.fromSeed(seedColor: accent, brightness: brightness).copyWith(
+    final ColorScheme scheme =
+        ColorScheme.fromSeed(seedColor: accent, brightness: brightness)
+            .copyWith(
       primary: accent,
       onPrimary: Colors.white,
       primaryContainer: accent.withValues(alpha: 0.2),
@@ -69,7 +98,8 @@ class ThemeConfig {
       surface: window,
       onSurface: onSurface,
       onSurfaceVariant: secondary,
-      surfaceContainerHighest: isDark ? const Color(0xFF2A2A2C) : const Color(0xFFE5E5EA),
+      surfaceContainerHighest:
+          isDark ? const Color(0xFF2A2A2C) : const Color(0xFFE5E5EA),
       outline: separator,
       error: error,
     );
@@ -79,29 +109,72 @@ class ThemeConfig {
       brightness: brightness,
       colorScheme: scheme,
       platform: GetPlatform.isMacOS ? TargetPlatform.macOS : TargetPlatform.iOS,
-      textTheme: const TextTheme(titleMedium: TextStyle(fontWeight: FontWeight.w400)),
+      textTheme:
+          const TextTheme(titleMedium: TextStyle(fontWeight: FontWeight.w400)),
       appBarTheme: AppBarTheme(
         backgroundColor: window,
         scrolledUnderElevation: 0,
         surfaceTintColor: Colors.transparent,
+        toolbarHeight: 48,
       ),
       navigationBarTheme: const NavigationBarThemeData(
         height: 48,
         surfaceTintColor: Colors.transparent,
         labelBehavior: NavigationDestinationLabelBehavior.alwaysHide,
       ),
-      popupMenuTheme: PopupMenuThemeData(surfaceTintColor: Colors.transparent, color: window),
-      dialogTheme: DialogThemeData(backgroundColor: window, surfaceTintColor: Colors.transparent),
+      popupMenuTheme: PopupMenuThemeData(
+        surfaceTintColor: Colors.transparent,
+        color: scheme.surfaceContainerHighest,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+      ),
+      dialogTheme: DialogThemeData(
+        backgroundColor: window,
+        surfaceTintColor: Colors.transparent,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        isDense: true,
+        filled: true,
+        fillColor: scheme.surfaceContainerHighest.withValues(alpha: 0.5),
+        contentPadding: const EdgeInsets.symmetric(horizontal: 10, vertical: 9),
+        border: inputBorder,
+        enabledBorder: inputBorder,
+        focusedBorder: inputBorder.copyWith(
+            borderSide: BorderSide(color: accent, width: 1.5)),
+      ),
       textSelectionTheme: TextSelectionThemeData(
         selectionColor: accent.withValues(alpha: 0.2),
         cursorColor: accent,
         selectionHandleColor: accent,
       ),
       dividerTheme: DividerThemeData(color: separator),
-      textButtonTheme: const TextButtonThemeData(style: ButtonStyle(mouseCursor: clickableMouseCursor)),
-      elevatedButtonTheme: const ElevatedButtonThemeData(style: ButtonStyle(mouseCursor: clickableMouseCursor)),
-      outlinedButtonTheme: const OutlinedButtonThemeData(style: ButtonStyle(mouseCursor: clickableMouseCursor)),
-      iconButtonTheme: const IconButtonThemeData(style: ButtonStyle(mouseCursor: clickableMouseCursor)),
+      textButtonTheme: const TextButtonThemeData(
+          style: ButtonStyle(mouseCursor: clickableMouseCursor)),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ButtonStyle(
+          mouseCursor: clickableMouseCursor,
+          elevation: const WidgetStatePropertyAll(0),
+          shape: WidgetStatePropertyAll(
+              RoundedRectangleBorder(borderRadius: controlRadius)),
+        ),
+      ),
+      outlinedButtonTheme: OutlinedButtonThemeData(
+        style: ButtonStyle(
+          mouseCursor: clickableMouseCursor,
+          shape: WidgetStatePropertyAll(
+              RoundedRectangleBorder(borderRadius: controlRadius)),
+          side: WidgetStatePropertyAll(BorderSide(color: separator)),
+        ),
+      ),
+      // Desktop tool icons live inside other MouseRegions (sidebar rows and
+      // action groups). Keep one stable macOS cursor/overlay state so they do
+      // not continually hand cursor ownership back and forth.
+      iconButtonTheme: const IconButtonThemeData(
+        style: ButtonStyle(
+          mouseCursor: WidgetStatePropertyAll(SystemMouseCursors.basic),
+          overlayColor: WidgetStatePropertyAll(Colors.transparent),
+        ),
+      ),
       listTileTheme: const ListTileThemeData(mouseCursor: clickableMouseCursor),
       switchTheme: const SwitchThemeData(mouseCursor: clickableMouseCursor),
       checkboxTheme: const CheckboxThemeData(mouseCursor: clickableMouseCursor),

--- a/lib/src/config/ui_config.dart
+++ b/lib/src/config/ui_config.dart
@@ -3,6 +3,8 @@ import 'dart:math';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:jhentai/src/config/theme_config.dart';
+import 'package:jhentai/src/setting/preference_setting.dart';
 import 'package:jhentai/src/setting/style_setting.dart';
 import 'package:loading_animation_widget/loading_animation_widget.dart';
 
@@ -43,6 +45,25 @@ class UIConfig {
   
   static const Color defaultLightThemeColor = Color(0xFF6750A4);
   static const Color defaultDarkThemeColor = Color(0xFFD0BCFF);
+
+  /// Liquid Glass bottom bar geometry (kept in sync with the bar in mobile_layout_page_v2.dart).
+  static const double liquidGlassNavBarHeight = 64;
+  static const double liquidGlassNavBarMarginBottom = 24;
+
+  /// The floating glass capsule's footprint above the safe-area inset
+  /// (bar height + bottom margin). 0 on desktop and non-Apple platforms.
+  static double liquidGlassNavBarRaise(BuildContext context) {
+    if (!ThemeConfig.isApple || styleSetting.isInDesktopLayout || preferenceSetting.hideBottomBar.value) {
+      return 0;
+    }
+    return liquidGlassNavBarHeight + liquidGlassNavBarMarginBottom;
+  }
+
+  /// Bottom content inset so a scrollable's last row clears the floating Liquid Glass
+  /// bar. Non-zero only on Apple mobile/tablet layouts where the bar overlays content;
+  /// 0 on desktop and non-Apple platforms.
+  static double liquidGlassNavContentInset(BuildContext context) =>
+      liquidGlassNavBarRaise(context) + MediaQuery.of(context).padding.bottom;
 
   static const Map<String, Color> galleryCategoryColor = {
     'Doujinshi': Color(0xfffc4e4e),
@@ -163,6 +184,13 @@ class UIConfig {
   static Color layoutDividerColor(BuildContext context) => Theme.of(context).colorScheme.surfaceContainerHighest;
 
   static Color desktopLeftTabIconColor(BuildContext context) => Theme.of(context).colorScheme.onSurface;
+
+  /// macOS sidebar background (light / dark).
+  static const Color desktopSideBarColorLight = Color(0xFFECECEC);
+  static const Color desktopSideBarColorDark = Color(0xFF2A2A2A);
+
+  static Color desktopSideBarColor(BuildContext context) =>
+      Theme.of(context).brightness == Brightness.dark ? desktopSideBarColorDark : desktopSideBarColorLight;
   static const double desktopTitleBarHeight = 32;
   static const double desktopFullScreenTopPadding = 12;
   static const double desktopLeftTabBarWidth = 56;
@@ -656,6 +684,25 @@ class UIConfig {
 
   /// blocking rule page
   static Color blockingRulePageHelpTextColor(BuildContext context) => Colors.grey.shade600;
+}
+
+/// Positions the [FloatingActionButton] above the floating Liquid Glass bar
+/// (Apple mobile/tablet layouts), keeping the default endFloat geometry otherwise.
+class GlassAwareFloatingActionButtonLocation extends FloatingActionButtonLocation {
+  final double glassRaise;
+
+  const GlassAwareFloatingActionButtonLocation(this.glassRaise);
+
+  @override
+  Offset getOffset(ScaffoldPrelayoutGeometry scaffoldGeometry) {
+    final double fabX = scaffoldGeometry.scaffoldSize.width - scaffoldGeometry.floatingActionButtonSize.width - 16;
+    final double fabY = scaffoldGeometry.scaffoldSize.height -
+        scaffoldGeometry.floatingActionButtonSize.height -
+        scaffoldGeometry.minInsets.bottom -
+        16 -
+        glassRaise;
+    return Offset(fabX, fabY);
+  }
 }
 
 class EHScrollBehaviourWithScrollBar extends MaterialScrollBehavior {

--- a/lib/src/config/ui_config.dart
+++ b/lib/src/config/ui_config.dart
@@ -48,7 +48,7 @@ class UIConfig {
 
   /// Liquid Glass bottom bar geometry (kept in sync with the bar in mobile_layout_page_v2.dart).
   static const double liquidGlassNavBarHeight = 64;
-  static const double liquidGlassNavBarMarginBottom = 24;
+  static const double liquidGlassNavBarMarginBottom = 8;
 
   /// The floating glass capsule's footprint above the safe-area inset
   /// (bar height + bottom margin). 0 on desktop and non-Apple platforms.
@@ -194,6 +194,7 @@ class UIConfig {
   static const double desktopTitleBarHeight = 32;
   static const double desktopFullScreenTopPadding = 12;
   static const double desktopLeftTabBarWidth = 56;
+  static const double desktopMacOSLeftTabBarWidth = 72;
   static const double desktopLeftTabBarItemHeight = 60;
   static const double desktopLeftTabBarTextHeight = 18;
 

--- a/lib/src/l18n/en_US.dart
+++ b/lib/src/l18n/en_US.dart
@@ -35,7 +35,8 @@ class en_US {
       'archiveError': 'Download Archive Error',
       'edit': 'Edit',
       'confirmDestructiveActions': 'Confirm destructive actions',
-      'confirmDestructiveActionsHint': 'Show a confirmation dialog before destructive actions such as deleting tasks or re-downloading in the download page',
+      'confirmDestructiveActionsHint':
+          'Show a confirmation dialog before destructive actions such as deleting tasks or re-downloading in the download page',
 
       'home': "Home",
       'gallery': "Gallery",
@@ -90,8 +91,10 @@ class en_US {
       'refreshIgneousFailed': 'Refresh Igneous Failed',
 
       /// request
-      'sadPanda': 'Sad Panda(no data). Refer: https://github.com/jiangtian616/JHenTai/wiki/Common-Questions',
-      'sadPandaReferLink': 'https://github.com/jiangtian616/JHenTai/wiki/Common-Questions',
+      'sadPanda':
+          'Sad Panda(no data). Refer: https://github.com/jiangtian616/JHenTai/wiki/Common-Questions',
+      'sadPandaReferLink':
+          'https://github.com/jiangtian616/JHenTai/wiki/Common-Questions',
 
       /// gallery card
       'filtered': 'Filtered',
@@ -130,10 +133,12 @@ class en_US {
       'noComments': 'No Comments',
       'lastEditedOn': 'Last edited on',
       'getGalleryDetailFailed': 'Get Gallery Detail Failed',
-      'cloudflare403': 'You have been restricted by Cloudflare from making network requests. Please try switching networks or using another login method.',
+      'cloudflare403':
+          'You have been restricted by Cloudflare from making network requests. Please try switching networks or using another login method.',
       'invisible2User': 'This Gallery is invisible to You',
       'invisibleHints': 'This gallery is removed or unavailable.',
-      'copyRightHints': 'This gallery is unavailable due to a copyright claim by: ',
+      'copyRightHints':
+          'This gallery is unavailable due to a copyright claim by: ',
       'refreshGalleryDetailsFailed': 'Refresh Gallery Details Failed',
       'failToGetThumbnails': "Fail To Get Thumbnails",
       'favoriteGallerySuccess': "Favorite Gallery Success",
@@ -141,7 +146,8 @@ class en_US {
       'removeFavoriteSuccess': "Remove Favorite Success",
       'removeFavoriteFailed': "Remove Favorite Failed",
       'getGalleryFavoriteInfoFailed': 'Get gallery favorite info failed',
-      'favoriteNoteSlotFullHint': 'Favorite note slot is full, please delete some notes first',
+      'favoriteNoteSlotFullHint':
+          'Favorite note slot is full, please delete some notes first',
       'ratingSuccess': 'Rating Success',
       'ratingFailed': 'Rating Failed',
       'voteTagFailed': 'Vote Tag Failed',
@@ -151,10 +157,12 @@ class en_US {
       'addNewTagSetSuccess': 'Add New Tag Set Success',
       'addNewWatchedTagSetSuccess': 'Add New Watched Tag Set Success',
       'addNewHiddenTagSetSuccess': 'Add New Hidden Tag Set Success',
-      'addNewTagSetSuccessHint': 'You can check your tags at Setting->EH->My Tags',
+      'addNewTagSetSuccessHint':
+          'You can check your tags at Setting->EH->My Tags',
       'addNewTagSetFailed': 'Add New Tag Set Failed',
       'VisitorStatistics': 'Visitor Statistics',
-      'invisible2UserWithoutDonation': 'This gallery\'s stats is invisible to user without donation',
+      'invisible2UserWithoutDonation':
+          'This gallery\'s stats is invisible to user without donation',
       'getGalleryStatisticsFailed': 'Get Gallery Statistics Failed',
       'totalVisits': 'Total Visits',
       'visits': 'Visits',
@@ -164,23 +172,29 @@ class en_US {
       'score': 'Score',
       'NotOnTheList': 'Not on the list',
       'getGalleryArchiveFailed': 'Get Gallery Archive Failed',
-      'parseGalleryArchiveFailed': 'Parse failed, make sure your [Archiver Settings] in e-hentai is [Manual Select, Manual Start (Default)]',
+      'parseGalleryArchiveFailed':
+          'Parse failed, make sure your [Archiver Settings] in e-hentai is [Manual Select, Manual Start (Default)]',
       'original': 'Original',
       'resample': 'Resample',
       'beginToDownloadArchive': 'Begin to Download Archive',
-      'beginToDownloadArchiveHint': 'You can check progress at Download -> Archive',
+      'beginToDownloadArchiveHint':
+          'You can check progress at Download -> Archive',
       'updateGalleryError': 'Update Gallery Error',
       'thisGalleryHasANewVersion': 'This gallery has a new version',
       'hasUpdated': 'Has updated',
       'unpackingArchiveError': 'Unpacking archive error',
       'failedToDealWith': 'Failed to deal with',
       'hasDownloaded': 'Has downloaded',
-      '410Hints': 'You have clocked too many downloaded bytes on this archive, and need to re-unlock of this archive to resume.',
-      '429Hints': 'Too many download requests! You\'d better decrease your archive download concurrency.',
-      'getUnpackedImagesFailedMsg': 'JHenTai can\'t load images of this archive, please check your local file.',
+      '410Hints':
+          'You have clocked too many downloaded bytes on this archive, and need to re-unlock of this archive to resume.',
+      '429Hints':
+          'Too many download requests! You\'d better decrease your archive download concurrency.',
+      'getUnpackedImagesFailedMsg':
+          'JHenTai can\'t load images of this archive, please check your local file.',
       'getGalleryTorrentsFailed': 'Get torrents failed',
       'chooseArchive': 'Choose Archive',
-      'tagSetExceedLimit': 'No more tags can be added because you have reach the limit',
+      'tagSetExceedLimit':
+          'No more tags can be added because you have reach the limit',
       'useTranslation': 'Use Translation',
       'addTagSuccess': 'Add Tag Success',
       'addTagFailed': 'Add Tag Failed',
@@ -221,8 +235,10 @@ class en_US {
       'loading': "Loading",
       'paused': 'Paused',
       'exceedImageLimits': "Exceed Image Limits",
-      'ehServerError': 'An error occurred due to EH\'s server, please try again later',
-      'unsupportedImagePageStyle': "JHenTai doesn't support Multi-Page Viewer(MPV), please change to default style in e-hentai.org",
+      'ehServerError':
+          'An error occurred due to EH\'s server, please try again later',
+      'unsupportedImagePageStyle':
+          "JHenTai doesn't support Multi-Page Viewer(MPV), please change to default style in e-hentai.org",
       'toNext': 'To next',
       'toPrev': 'To prev',
       'back': 'Back',
@@ -259,9 +275,11 @@ class en_US {
       /// eh setting page
       'site': 'Site',
       'redirect2Eh': 'Redirect to EH if available',
-      'redirect2EhHint': 'Try to load gallery detail page from EH site first to get better network performance',
+      'redirect2EhHint':
+          'Try to load gallery detail page from EH site first to get better network performance',
       'redirectAllGallery': 'Redirect all gallery to EH',
-      'imDonorHint': 'If you are a donor, you can turn this on to help you access gallerys in EX site',
+      'imDonorHint':
+          'If you are a donor, you can turn this on to help you access gallerys in EX site',
       'profileSetting': 'Profile Setting',
       'chooseProfileHint': 'Choose profile used in JHenTai',
       'siteSetting': 'Site Setting',
@@ -316,14 +334,19 @@ class en_US {
       'enableTagZHTranslation': 'Translate Tag Name into Chinese',
       'version': 'Version',
       'downloadTagTranslationHint': 'Downloading data..., downloaded: ',
-      'zhTagSearchOrderOptimization': 'Chinese Tag Auto-Completion Ordering Rule',
-      'zhTagSearchOrderOptimizationHint': 'Intelligent sorting by default and sort by frequency if enabled',
+      'zhTagSearchOrderOptimization':
+          'Chinese Tag Auto-Completion Ordering Rule',
+      'zhTagSearchOrderOptimizationHint':
+          'Intelligent sorting by default and sort by frequency if enabled',
       'themeMode': 'Theme Mode',
       'dark': 'Dark',
       'light': 'Light',
       'followSystem': 'Follow System',
       'themeColor': 'Theme Color',
       'themeColorFixedOnApple': 'Fixed accent on macOS / iOS',
+      'appleVisualStyle': 'Apple visual style',
+      'appleVisualStyleHint':
+          'Enable the redesigned interface on macOS and iOS',
       'listStyle': 'Gallery List Style (Global)',
       'flat': 'Flat',
       'flatWithoutTags': 'Flat(Without Tags)',
@@ -334,8 +357,10 @@ class en_US {
       'waterfallFlowBig': 'Waterfall Flow (Big)',
       'crossAxisCountInWaterFallFlow': 'Waterfall Flow Column Count',
       'pageListStyle': 'Gallery List Style (Page)',
-      'crossAxisCountInGridDownloadPageForGroup': 'Download Page Grid Column Count(Group)',
-      'crossAxisCountInGridDownloadPageForGallery': 'Download Page Grid Column Count(Gallery)',
+      'crossAxisCountInGridDownloadPageForGroup':
+          'Download Page Grid Column Count(Group)',
+      'crossAxisCountInGridDownloadPageForGallery':
+          'Download Page Grid Column Count(Gallery)',
       'crossAxisCountInDetailPage': 'Detail Page Thumbnail Column Count',
       'global': 'Global',
       'auto': 'Auto',
@@ -350,7 +375,8 @@ class en_US {
       'whenScrollUp': 'When Scroll Up',
       'whenScrollDown': 'When Scroll Down',
       'preloadGalleryCover': 'Preload gallery cover',
-      'preloadGalleryCoverHint': 'Preload the covers of galleries that are not yet displayed on the page',
+      'preloadGalleryCoverHint':
+          'Preload the covers of galleries that are not yet displayed on the page',
       'enableSwipeBackGesture': 'Enable Swipe Back Gesture',
       'enableLeftMenuDrawerGesture': 'Enable Left Menu Drawer Gesture',
       'enableQuickSearchDrawerGesture': 'Enable QuickSearch Drawer Gesture',
@@ -368,28 +394,35 @@ class en_US {
       'inheritAll': 'Inherit All',
       'inheritAllHint': 'Use last search options for next search',
       'inheritPartially': 'Inherit Partially',
-      'inheritPartiallyHint': 'Use last search options for next search(except language and category)',
+      'inheritPartiallyHint':
+          'Use last search options for next search(except language and category)',
       'none': 'None',
       'noneHint': 'Use default search options for next search',
       'showAllGalleryTitles': 'Show All Gallery Titles',
-      'showAllGalleryTitlesHint': 'Show both original and japanese titles if available',
+      'showAllGalleryTitlesHint':
+          'Show both original and japanese titles if available',
       'showGalleryTagVoteStatus': 'Show Gallery Tag Vote Status',
-      'showGalleryTagVoteStatusHint': 'Include confidence, skepticism and incorrect',
+      'showGalleryTagVoteStatusHint':
+          'Include confidence, skepticism and incorrect',
       'showComments': 'Show Comments',
       'showAllComments': 'Show All Comments',
-      'showAllCommentsHint': 'By default only the 45 highest scoring and 5 most recent comments will be shown',
+      'showAllCommentsHint':
+          'By default only the 45 highest scoring and 5 most recent comments will be shown',
       'addTag': 'Add Tag',
       'addTagHint': 'Enter new tags, separated with comma',
 
       /// theme color setting page
-      'themeColorSettingHint': 'Assign different color for light and dark theme',
+      'themeColorSettingHint':
+          'Assign different color for light and dark theme',
       'preview': 'Preview',
       'preset': 'Preset',
       'custom': 'Custom',
 
       /// performance setting page
-      'maxGalleryNum4Animation': 'Max Gallery Num For List Animation in Download page',
-      'maxGalleryNum4AnimationHint': 'Disable animation for groups which have more gallerys than this value(for list style)',
+      'maxGalleryNum4Animation':
+          'Max Gallery Num For List Animation in Download page',
+      'maxGalleryNum4AnimationHint':
+          'Disable animation for groups which have more gallerys than this value(for list style)',
 
       /// mouse wheel setting page
       'wheelScrollSpeed': 'Wheel scroll speed',
@@ -401,7 +434,8 @@ class en_US {
       'hostMapping': 'Host Mapping',
       'hostMappingHint': 'Used for domain fronting',
       'proxyAddress': 'Proxy Address',
-      'proxyAddressHint': 'If you use proxy server, make sure to set it up correctly',
+      'proxyAddressHint':
+          'If you use proxy server, make sure to set it up correctly',
       'saveSuccess': 'Save success',
       'saveFailed': 'Save failed',
       'updateSuccess': 'Update success',
@@ -410,7 +444,8 @@ class en_US {
       'pageCacheMaxAge': 'Page Cache Expiration Time',
       'pageCacheMaxAgeHint': 'You can update cache by refresh page',
       'cacheImageExpireDuration': 'Image Cache Expiration Time',
-      'cacheImageExpireDurationHint': 'Remove image cache automatically after launching app',
+      'cacheImageExpireDurationHint':
+          'Remove image cache automatically after launching app',
       'oneMinute': '1 Minute',
       'tenMinute': '10 Minute',
       'oneHour': '1 Hour',
@@ -429,18 +464,22 @@ class en_US {
       'superResolution': 'Image Super Resolution',
       'stopSuperResolution': 'Stop Super Resolution',
       'deleteSuperResolvedImage': 'Delete Super Resolved Image',
-      'superResolveOriginalImageHint': 'Process original image cost more time, space and performance, are you sure to continue?',
+      'superResolveOriginalImageHint':
+          'Process original image cost more time, space and performance, are you sure to continue?',
       'verityAppLinks4Android12': 'Verity App Links(Android 12+)',
-      'verityAppLinks4Android12Hint': 'For Android 12+, you need to manually add link to verified links in order to open JHenTai in 3-rd apps',
+      'verityAppLinks4Android12Hint':
+          'For Android 12+, you need to manually add link to verified links in order to open JHenTai in 3-rd apps',
       'noImageMode': 'No Image Mode',
       'exportData': 'Export Data',
       'exportDataHint': 'Export configs, block rules and history',
       'selectExportItems': 'Select Export Items',
       'importData': 'Import Data',
-      'importDataHint': 'App will shutdown automatically after importing to apply the latest configuration',
+      'importDataHint':
+          'App will shutdown automatically after importing to apply the latest configuration',
 
       /// host mapping page
-      'hostDataSource': 'No need to change by default.\nData source: https://dns.google/',
+      'hostDataSource':
+          'No need to change by default.\nData source: https://dns.google/',
 
       /// proxy page
       'proxySetting': 'Proxy Setting',
@@ -459,7 +498,8 @@ class en_US {
       'enableAuthOnResumeHints': '3 seconds delay',
       'enableBlurBackgroundApp': 'Enable Blur Page When Switch to Background',
       'hideImagesInAlbum': 'Hide Images in Album',
-      'hideImagesInAlbumHints': 'If you changed default download path, you need to create .nomedia manually',
+      'hideImagesInAlbumHints':
+          'If you changed default download path, you need to create .nomedia manually',
 
       /// read setting page
       'enableImmersiveMode': 'Enable Immersive Mode',
@@ -472,13 +512,16 @@ class en_US {
       'landscape': 'Landscape',
       'portrait': 'Portrait',
       'readDirection': 'Read Direction',
-      'enableOrientationSpecificReadDirection': 'Orientation-Specific Read Direction',
-      'enableOrientationSpecificReadDirectionHint': 'Set different read directions for portrait and landscape orientations',
+      'enableOrientationSpecificReadDirection':
+          'Orientation-Specific Read Direction',
+      'enableOrientationSpecificReadDirectionHint':
+          'Set different read directions for portrait and landscape orientations',
       'portraitReadDirection': 'Portrait Read Direction',
       'landscapeReadDirection': 'Landscape Read Direction',
       'autoSwitchedReadDirection': 'Auto-switched read direction',
       'notchOptimization': 'Notch Optimization',
-      'notchOptimizationHint': 'Add padding before the first image to avoid the notch and status bar',
+      'notchOptimizationHint':
+          'Add padding before the first image to avoid the notch and status bar',
       'imageRegionWidthRatio': 'Image Region Width Ratio',
       'portraitImageRegionWidthRatio': 'Portrait Image Width Ratio',
       'landscapeImageRegionWidthRatio': 'Landscape Image Width Ratio',
@@ -502,7 +545,8 @@ class en_US {
       'left2rightList': 'Left to Right (Continuous)',
       'right2leftList': 'Right to Left (Continuous)',
       'enablePageTurnByVolumeKeys': 'Use volume key to turn page',
-      'enablePageTurnByVolumeKeysHint': 'On iOS, if the volume is at 0 or 100%, it will be adjusted automatically when entering the reader to support page turning, and restored on exit',
+      'enablePageTurnByVolumeKeysHint':
+          'On iOS, if the volume is at 0 or 100%, it will be adjusted automatically when entering the reader to support page turning, and restored on exit',
       'enablePageTurnAnime': 'Enable Turn Page Animation',
       'enableDoubleTapToScaleUp': 'Enable Double Tap to Scale up',
       'enableTapDragToScaleUp': 'Enable Tap Drag to Scale up',
@@ -514,7 +558,8 @@ class en_US {
       'turnPageModeHint': 'To next screen or next image',
       'enableImageMaxKilobytes': 'Enable Image Compression',
       'imageMaxKilobytes': 'Image Max Size',
-      'imageMaxKilobytesHint': 'Images larger than this size will be compressed',
+      'imageMaxKilobytesHint':
+          'Images larger than this size will be compressed',
       'image': 'Image',
       'screen': 'Screen',
       'preloadDistanceInOnlineMode': 'Preload Distance(Online)',
@@ -522,6 +567,12 @@ class en_US {
       'ScreenHeight': 'Screen',
       'preloadPageCount': 'Preload Page Count(Online)',
       'preloadPageCountInLocalMode': 'Preload Page Count(Local)',
+      'failedImageRetryScope': "Retry Failed Images",
+      'failedImageRetryScopeHint':
+          "Scope when tapping a failed online image to reload it",
+      'retrySingleImage': "Only the tapped image",
+      'retryCurrentPageAndAfter': "Current image and after",
+      'retryAllFailedImages': "All failed images",
       'continuousScroll': 'Continuous Scroll',
       'continuousScrollHint': 'Splice multiple images',
       'doubleColumn': 'Double Column',
@@ -587,9 +638,12 @@ class en_US {
       'needReUnlock': 'Need Re-Unlock',
       'reUnlock': 'Re-Unlock',
       'reUnlockHint': 'Attention! Re-unlock need to buy this archive again.',
-      'downloadHelpInfo': 'If you can\'t download and find errors like table doesn\'t exist in logs, please uninstall current app and re-install.',
-      'localGalleryHelpInfo': 'Load gallerys which is not downloaded by JHenTai. Add config in Download Setting -> Extra Gallery Scan Path and then refresh.',
-      'localGalleryHelpInfo4iOSAndMacOS': 'Load gallerys which is not downloaded by JHenTai. Put your gallerys in default download path and then refresh',
+      'downloadHelpInfo':
+          'If you can\'t download and find errors like table doesn\'t exist in logs, please uninstall current app and re-install.',
+      'localGalleryHelpInfo':
+          'Load gallerys which is not downloaded by JHenTai. Add config in Download Setting -> Extra Gallery Scan Path and then refresh.',
+      'localGalleryHelpInfo4iOSAndMacOS':
+          'Load gallerys which is not downloaded by JHenTai. Put your gallerys in default download path and then refresh',
       'deleteLocalGalleryHint': 'Delete your local files',
       'priority': 'Priority',
       'highest': 'Highest',
@@ -616,11 +670,16 @@ class en_US {
       'multiReDownloadHint': 'You will re-download all selected gallerys.',
       'multiChangeGroupHint': 'You will change group of all selected gallerys.',
       'multiDeleteHint': 'You will delete all selected gallerys.',
-      'blankImageHint': 'Downloading the image returned an empty result, trying to re-parse.',
-      'peakHoursHint': 'Downloading original files during peak hours requires GP, and you do not have enough, downloading is paused.',
-      'oldGalleryHint': 'Downloading original files of this gallery requires GP, and you do not have enough.',
-      'exceedLimitHint': 'You have reached the image limit, and do not have sufficient GP to buy a download quota.',
-      'deleteUpdatingDependentHint': 'Another gallery\'s update relies on current gallery, you\'d better delete after update has completed.',
+      'blankImageHint':
+          'Downloading the image returned an empty result, trying to re-parse.',
+      'peakHoursHint':
+          'Downloading original files during peak hours requires GP, and you do not have enough, downloading is paused.',
+      'oldGalleryHint':
+          'Downloading original files of this gallery requires GP, and you do not have enough.',
+      'exceedLimitHint':
+          'You have reached the image limit, and do not have sufficient GP to buy a download quota.',
+      'deleteUpdatingDependentHint':
+          'Another gallery\'s update relies on current gallery, you\'d better delete after update has completed.',
       'migrateToDownload': 'Migrate To 「Download」',
       'refresh': 'Refresh',
 
@@ -661,7 +720,8 @@ class en_US {
       'pageAtLeast': 'Page At Least',
       'pageAtMost': 'Page At Most',
       'pagesBetween': 'Pages Between',
-      'pageRangeSelectHint': 'min <= 1000, max >= 10\nmin/max <= 0.8, max-min >= 20',
+      'pageRangeSelectHint':
+          'min <= 1000, max >= 10\nmin/max <= 0.8, max-min >= 20',
       'to': 'to',
       'minimumRating': 'Minimum Rating',
       'disableFilterForLanguage': 'Disable Filter For Language',
@@ -715,14 +775,17 @@ class en_US {
       'originalImage': 'Original',
       'resampleImage': 'Resample',
       'defaultGalleryGroup': 'Default Gallery Group',
-      'prioritizeRecentGalleryGroups': 'Prioritize Recently Used Gallery Groups',
+      'prioritizeRecentGalleryGroups':
+          'Prioritize Recently Used Gallery Groups',
       'defaultArchiveGroup': 'Default Archive Group',
       'never': 'Never',
       'manual': 'Manual',
       'always': 'Always',
       'longPress2Reset': 'Long Press to Reset',
-      'needPermissionToChangeDownloadPath': 'Need permission to change download path',
-      'invalidPath': 'Invalid Path. Avoid using SD-Card, system path or root path.',
+      'needPermissionToChangeDownloadPath':
+          'Need permission to change download path',
+      'invalidPath':
+          'Invalid Path. Avoid using SD-Card, system path or root path.',
       'downloadTaskConcurrency': 'Download Concurrency',
       'needRestart': 'Need restart',
       'speedLimit': 'Speed Limit',
@@ -730,16 +793,22 @@ class en_US {
       'per': 'per',
       'images': 'images',
       'downloadTimeout': 'Download Timeout',
-      'downloadAllGallerysOfSamePriority': 'Download All Gallerys of Same Priority',
-      'downloadAllGallerysOfSamePriorityHint': 'Download only 1 gallery simultaneously in 1 group with highest priority by default',
+      'downloadAllGallerysOfSamePriority':
+          'Download All Gallerys of Same Priority',
+      'downloadAllGallerysOfSamePriorityHint':
+          'Download only 1 gallery simultaneously in 1 group with highest priority by default',
       'alwaysUseDefaultGroup': 'Always Use Default Group',
       'enableStoreMetadataForRestore': 'Enable Store Metadata for Restore',
-      'enableStoreMetadataForRestoreHint': 'If disable this, you can\'t restore download tasks',
+      'enableStoreMetadataForRestoreHint':
+          'If disable this, you can\'t restore download tasks',
       'archiveDownloadIsolateCount': 'Archive Download Thread Count',
-      'archiveDownloadIsolateCountHint': 'Sum of threads for all tasks needs to be less than 10, otherwise the download will fail',
+      'archiveDownloadIsolateCountHint':
+          'Sum of threads for all tasks needs to be less than 10, otherwise the download will fail',
       'manageArchiveDownloadConcurrency': 'Manage Archive Download Concurrency',
-      'manageArchiveDownloadConcurrencyHint': 'Archive will wait until there are enough threads to download',
-      'deleteArchiveFileAfterDownload': 'Delete Archive .zip File After Download',
+      'manageArchiveDownloadConcurrencyHint':
+          'Archive will wait until there are enough threads to download',
+      'deleteArchiveFileAfterDownload':
+          'Delete Archive .zip File After Download',
       'restoreDownloadTasks': 'Restore Download Tasks',
       'restoreDownloadTasksHint': 'Restore download tasks by metadata',
       'restoreDownloadTasksSuccess': 'Restore Download Tasks Success',
@@ -747,9 +816,12 @@ class en_US {
       'restoredGalleryCount': 'Restored gallery count',
       'restoredArchiveCount': 'Restored archive count',
       'restoreTasksAutomatically': 'Restore Tasks Automatically',
-      'restoreTasksAutomaticallyHint': 'Restore tasks automatically when app launched',
-      'brokenDownloadPathHint': 'Seems your download path is broken, download function may be ineffective',
-      'brokenExtraScanPathHint': 'Seems your default local gallery path is broken, local gallery may be not recognized',
+      'restoreTasksAutomaticallyHint':
+          'Restore tasks automatically when app launched',
+      'brokenDownloadPathHint':
+          'Seems your download path is broken, download function may be ineffective',
+      'brokenExtraScanPathHint':
+          'Seems your default local gallery path is broken, local gallery may be not recognized',
       'useJH2UpdateGallery': 'Use JH server to accelerate gallery updates',
 
       /// archive bot settings
@@ -766,7 +838,8 @@ class en_US {
       'checkInFailed': 'Check-in failed',
       'checkInSuccess': 'Check-in success',
       'checkInSuccessHint': 'Got GP: %s, current total GP: %s.',
-      'pauseDownloadByInvalidArchiveBotKey': 'Archive bot settings is invalid, download paused',
+      'pauseDownloadByInvalidArchiveBotKey':
+          'Archive bot settings is invalid, download paused',
       'chooseArchiveParseSource': 'Change Parse Source',
       'official': 'Official',
       'archiveBot': 'Archive Bot',
@@ -795,7 +868,8 @@ class en_US {
       'upload2cloud': 'Upload to Cloud',
       'upload2cloudHint': 'Upload your current local configuration',
       'tap2upload': 'Tap to upload',
-      'copyIdentificationCodeSuccess': 'Upload successfully. Identification code has been copied',
+      'copyIdentificationCodeSuccess':
+          'Upload successfully. Identification code has been copied',
       'copyShareCode': 'Copy Share Code',
       'import': 'Import',
       'save2Local': 'Save to Local',
@@ -811,9 +885,11 @@ class en_US {
       'inputNumberHint': 'Please input a correct number',
       'inputRegexHint': 'Please input a correct regex',
       'useBuiltInBlockedUsers': 'Enable Built-in User Blocklist',
-      'useBuiltInBlockedUsersHint': 'Filter out gallery comments from users on the blocklist',
+      'useBuiltInBlockedUsersHint':
+          'Filter out gallery comments from users on the blocklist',
       'blockingRules': 'Block Rules',
-      'blockingRulesHint': 'Additional blocking rules for gallerys and comments',
+      'blockingRulesHint':
+          'Additional blocking rules for gallerys and comments',
       'blockingTarget': 'Blocking Target',
       'blockingAttribute': 'Blocking Attribute',
       'blockingPattern': 'Blocking Pattern',
@@ -827,7 +903,8 @@ class en_US {
       'content': 'Content',
       'incompleteInformation': 'Incomplete information',
       'noBlockingRuleHint': 'Add at least 1 rule',
-      'notSameBlockingRuleTargetHint': 'All sub-rules should have the same blocking target',
+      'notSameBlockingRuleTargetHint':
+          'All sub-rules should have the same blocking target',
       'blockingRuleHelp': '''
 Blocking Target: Filter galleries on the list page or filter comments on the details page. All sub-rules under the same rule must have the same blocking target.
 Blocking Attribute: Specify the attribute of the target based on which the rule is written to block.

--- a/lib/src/l18n/en_US.dart
+++ b/lib/src/l18n/en_US.dart
@@ -323,6 +323,7 @@ class en_US {
       'light': 'Light',
       'followSystem': 'Follow System',
       'themeColor': 'Theme Color',
+      'themeColorFixedOnApple': 'Fixed accent on macOS / iOS',
       'listStyle': 'Gallery List Style (Global)',
       'flat': 'Flat',
       'flatWithoutTags': 'Flat(Without Tags)',

--- a/lib/src/l18n/ko_KR.dart
+++ b/lib/src/l18n/ko_KR.dart
@@ -35,7 +35,8 @@ class ko_KR {
       'archiveError': 'Download Archive Error',
       'edit': 'Edit',
       'confirmDestructiveActions': '파괴적 작업 확인',
-      'confirmDestructiveActionsHint': '켜면 다운로드 페이지에서 작업 삭제, 다시 다운로드 등 파괴적 작업 전에 확인 대화상자가 표시됩니다',
+      'confirmDestructiveActionsHint':
+          '켜면 다운로드 페이지에서 작업 삭제, 다시 다운로드 등 파괴적 작업 전에 확인 대화상자가 표시됩니다',
 
       'home': "홈",
       'gallery': "갤러리",
@@ -90,8 +91,10 @@ class ko_KR {
       'refreshIgneousFailed': 'Refresh Igneous Failed',
 
       /// request
-      'sadPanda': 'Sad Panda(no data). Refer: https://github.com/jiangtian616/JHenTai/wiki/%EC%9E%90%EC%A3%BC-%ED%95%98%EB%8A%94-%EC%A7%88%EB%AC%B8',
-      'sadPandaReferLink': 'https://github.com/jiangtian616/JHenTai/wiki/%EC%9E%90%EC%A3%BC-%ED%95%98%EB%8A%94-%EC%A7%88%EB%AC%B8',
+      'sadPanda':
+          'Sad Panda(no data). Refer: https://github.com/jiangtian616/JHenTai/wiki/%EC%9E%90%EC%A3%BC-%ED%95%98%EB%8A%94-%EC%A7%88%EB%AC%B8',
+      'sadPandaReferLink':
+          'https://github.com/jiangtian616/JHenTai/wiki/%EC%9E%90%EC%A3%BC-%ED%95%98%EB%8A%94-%EC%A7%88%EB%AC%B8',
 
       /// gallery card
       'filtered': 'Filtered',
@@ -130,7 +133,8 @@ class ko_KR {
       'noComments': '댓글 없음',
       'lastEditedOn': '최근 수정일: ',
       'getGalleryDetailFailed': '갤러리 세부 정보 가져오기 실패',
-      'cloudflare403': 'You have been restricted by Cloudflare from making network requests. Please try switching networks or using another login method.',
+      'cloudflare403':
+          'You have been restricted by Cloudflare from making network requests. Please try switching networks or using another login method.',
       'invisible2User': '이 갤러리는 사용자에게 보이지 않습니다.',
       'invisibleHints': '이 갤러리는 삭제되었거나 사용할 수 없습니다.',
       'copyRightHints': '이 갤러리는 다음 저작권자로 인해 사용할 수 없음: ',
@@ -141,7 +145,8 @@ class ko_KR {
       'removeFavoriteSuccess': "Remove Favorite Success",
       'removeFavoriteFailed': "Remove Favorite Failed",
       'getGalleryFavoriteInfoFailed': 'Get gallery favorite info failed',
-      'favoriteNoteSlotFullHint': 'Favorite note slot is full, please delete some notes first',
+      'favoriteNoteSlotFullHint':
+          'Favorite note slot is full, please delete some notes first',
       'ratingSuccess': '평가 성공',
       'ratingFailed': '평가 실패',
       'voteTagFailed': '태그 투표 실패',
@@ -164,7 +169,8 @@ class ko_KR {
       'score': '점수',
       'NotOnTheList': '순위권 밖',
       'getGalleryArchiveFailed': '갤러리 아카이브 가져오기 실패',
-      'parseGalleryArchiveFailed': '설정 불러오기 실패, e-hentai에서 [Archiver Settings]가 [Manual Select, Manual Start (Default)]인지 확인하세요.',
+      'parseGalleryArchiveFailed':
+          '설정 불러오기 실패, e-hentai에서 [Archiver Settings]가 [Manual Select, Manual Start (Default)]인지 확인하세요.',
       'original': '원본',
       'resample': '압축',
       'beginToDownloadArchive': '아카이브 다운로드 시작',
@@ -176,8 +182,10 @@ class ko_KR {
       'failedToDealWith': '처리 실패',
       'hasDownloaded': '다운로드 완료',
       '410Hints': '이 아카이브에서 다운로드한 용량이 너무 많아서 다시 시작하려면 아카이브의 잠금을 다시 해제해야 합니다.',
-      '429Hints': 'Too many download requests! You\'d better decrease your archive download concurrency.',
-      'getUnpackedImagesFailedMsg': 'JHenTai에서 이 아카이브 이미지를 가져올 수 없습니다. 로컬 파일을 확인하세요.',
+      '429Hints':
+          'Too many download requests! You\'d better decrease your archive download concurrency.',
+      'getUnpackedImagesFailedMsg':
+          'JHenTai에서 이 아카이브 이미지를 가져올 수 없습니다. 로컬 파일을 확인하세요.',
       'getGalleryTorrentsFailed': '토렌트 불러오기 실패',
       'chooseArchive': '아카이브 선택',
       'tagSetExceedLimit': '저장된 태그 수가 최대치에 도달해서 더 추가할 수 없습니다.',
@@ -221,8 +229,10 @@ class ko_KR {
       'loading': "로딩",
       'paused': '일시 정지',
       'exceedImageLimits': "이미지 한도 초과",
-      'ehServerError': 'An error occurred due to EH\'s server, please try again later',
-      'unsupportedImagePageStyle': "JHenTai는 Multi-Page Viewer(MPV)를 지원하지 않습니다. e-hentai.org에서 기본값 스타일로 해주세요.",
+      'ehServerError':
+          'An error occurred due to EH\'s server, please try again later',
+      'unsupportedImagePageStyle':
+          "JHenTai는 Multi-Page Viewer(MPV)를 지원하지 않습니다. e-hentai.org에서 기본값 스타일로 해주세요.",
       'toNext': '다음',
       'toPrev': '이전',
       'back': '뒤로',
@@ -259,9 +269,11 @@ class ko_KR {
       /// eh setting page
       'site': '사이트',
       'redirect2Eh': '사용 가능하면 EH로 재요청',
-      'redirect2EhHint': 'Try to load gallery detail page from EH site first to get better network performance',
+      'redirect2EhHint':
+          'Try to load gallery detail page from EH site first to get better network performance',
       'redirectAllGallery': 'Redirect all gallery to EH',
-      'imDonorHint': 'If you are a donor, you can turn this on to help you access gallerys in EX site',
+      'imDonorHint':
+          'If you are a donor, you can turn this on to help you access gallerys in EX site',
       'profileSetting': 'Profile Setting',
       'chooseProfileHint': 'Choose profile used in JHenTai',
       'siteSetting': '사이트 내부 설정',
@@ -316,14 +328,18 @@ class ko_KR {
       'enableTagZHTranslation': '태그를 중국어로 변환',
       'version': '버전',
       'downloadTagTranslationHint': '데이터 다운로드 중...: ',
-      'zhTagSearchOrderOptimization': 'Chinese Tag Auto-Completion Ordering Rule',
-      'zhTagSearchOrderOptimizationHint': 'Intelligent sorting by default and sort by frequency if enabled',
+      'zhTagSearchOrderOptimization':
+          'Chinese Tag Auto-Completion Ordering Rule',
+      'zhTagSearchOrderOptimizationHint':
+          'Intelligent sorting by default and sort by frequency if enabled',
       'themeMode': '테마 모드',
       'dark': '어두운 모드',
       'light': '밝은 모드',
       'followSystem': '시스템에 따라',
       'themeColor': '테마 색상',
       'themeColorFixedOnApple': 'macOS / iOS에서 고정 강조색 사용',
+      'appleVisualStyle': 'Apple 시각 스타일',
+      'appleVisualStyleHint': 'macOS 및 iOS에서 새롭게 디자인된 인터페이스 사용',
       'listStyle': '갤러리 리스트 스타일 (기본값)',
       'flat': '플랫',
       'flatWithoutTags': '플랫(태그 없음)',
@@ -335,7 +351,8 @@ class ko_KR {
       'crossAxisCountInWaterFallFlow': '폭포의 세로줄 개수',
       'pageListStyle': '갤러리 리스트 스타일 (개별)',
       'crossAxisCountInGridDownloadPageForGroup': '다운로드 페이지 그리드 정렬 세로줄 개수(폴더)',
-      'crossAxisCountInGridDownloadPageForGallery': '다운로드 페이지 그리드 정렬 세로줄 개수(폴더 내부)',
+      'crossAxisCountInGridDownloadPageForGallery':
+          '다운로드 페이지 그리드 정렬 세로줄 개수(폴더 내부)',
       'crossAxisCountInDetailPage': 'Detail Page Thumbnail Column Count',
       'global': '기본값',
       'auto': '자동',
@@ -350,7 +367,8 @@ class ko_KR {
       'whenScrollUp': 'When Scroll Up',
       'whenScrollDown': 'When Scroll Down',
       'preloadGalleryCover': 'Preload gallery cover',
-      'preloadGalleryCoverHint': 'Preload the covers of galleries that are not yet displayed on the page',
+      'preloadGalleryCoverHint':
+          'Preload the covers of galleries that are not yet displayed on the page',
       'enableSwipeBackGesture': '스와이프 제스처로 뒤로 가기 활성화',
       'enableLeftMenuDrawerGesture': '좌측 서랍 메뉴 제스처로 열기 활성화',
       'enableQuickSearchDrawerGesture': '우측 빠른 검색 메뉴 제스처로 열기 활성화',
@@ -368,16 +386,20 @@ class ko_KR {
       'inheritAll': 'Inherit All',
       'inheritAllHint': 'Use last search options for next search',
       'inheritPartially': 'Inherit Partially',
-      'inheritPartiallyHint': 'Use last search options for next search(except language and category)',
+      'inheritPartiallyHint':
+          'Use last search options for next search(except language and category)',
       'none': 'None',
       'noneHint': 'Use default search options for next search',
       'showAllGalleryTitles': 'Show All Gallery Titles',
-      'showAllGalleryTitlesHint': 'Show both original and japanese titles if available',
+      'showAllGalleryTitlesHint':
+          'Show both original and japanese titles if available',
       'showGalleryTagVoteStatus': 'Show Gallery Tag Vote Status',
-      'showGalleryTagVoteStatusHint': 'Include confidence, skepticism and incorrect',
+      'showGalleryTagVoteStatusHint':
+          'Include confidence, skepticism and incorrect',
       'showComments': 'Show Comments',
       'showAllComments': 'Show All Comments',
-      'showAllCommentsHint': 'By default only the 45 highest scoring and 5 most recent comments will be shown',
+      'showAllCommentsHint':
+          'By default only the 45 highest scoring and 5 most recent comments will be shown',
       'addTag': 'Add Tag',
       'addTagHint': 'Enter new tags, separated with comma',
 
@@ -386,8 +408,10 @@ class ko_KR {
       'custom': '커스텀',
 
       /// performance setting page
-      'maxGalleryNum4Animation': 'Max Gallery Num For List Animation in Download page',
-      'maxGalleryNum4AnimationHint': 'Disable animation for groups which have more gallerys than this value(for list style)',
+      'maxGalleryNum4Animation':
+          'Max Gallery Num For List Animation in Download page',
+      'maxGalleryNum4AnimationHint':
+          'Disable animation for groups which have more gallerys than this value(for list style)',
 
       /// mouse wheel setting page
       'themeColorSettingHint': '라이트 모드와 다크 모드 각각에 다른 색을 지정합니다',
@@ -410,7 +434,8 @@ class ko_KR {
       'pageCacheMaxAge': '페이지 캐시의 수명 최대 시간',
       'pageCacheMaxAgeHint': '새로고침 페이지 별로 캐시를 업데이트할 수 있습니다.',
       'cacheImageExpireDuration': 'Image Cache Expiration Time',
-      'cacheImageExpireDurationHint': 'Remove image cache automatically after launching app',
+      'cacheImageExpireDurationHint':
+          'Remove image cache automatically after launching app',
       'oneMinute': '1분',
       'tenMinute': '10분',
       'oneHour': '1시간',
@@ -429,15 +454,18 @@ class ko_KR {
       'superResolution': '초고해상도 이미지 생성',
       'stopSuperResolution': '초고해상도 이미지 생성 취소',
       'deleteSuperResolvedImage': '초고해상도 이미지 삭제',
-      'superResolveOriginalImageHint': '원본 이미지 처리는 더 많은 시간과 공간, 성능을 사용합니다. 계속하시겠습니까?',
+      'superResolveOriginalImageHint':
+          '원본 이미지 처리는 더 많은 시간과 공간, 성능을 사용합니다. 계속하시겠습니까?',
       'verityAppLinks4Android12': 'Verity App Links(Android 12+)',
-      'verityAppLinks4Android12Hint': 'For Android 12+, you need to manually add link to verified links in order to open JHenTai in 3-rd apps',
+      'verityAppLinks4Android12Hint':
+          'For Android 12+, you need to manually add link to verified links in order to open JHenTai in 3-rd apps',
       'noImageMode': 'No Image Mode',
       'exportData': 'Export Data',
       'exportDataHint': 'Export configs, block rules and history',
       'selectExportItems': 'Select Export Items',
       'importData': 'Import Data',
-      'importDataHint': 'App will shutdown automatically after importing to apply the latest configuration',
+      'importDataHint':
+          'App will shutdown automatically after importing to apply the latest configuration',
 
       /// host mapping page
       'hostDataSource': '기본적으로 변경할 필요는 없습니다.\n데이터 소스: https://dns.google/',
@@ -459,7 +487,8 @@ class ko_KR {
       'enableAuthOnResumeHints': '3초 후 인증 요구',
       'enableBlurBackgroundApp': '백그라운드로 전환할 때 페이지 블러 사용',
       'hideImagesInAlbum': 'Hide Images in Album',
-      'hideImagesInAlbumHints': 'If you changed default download path, you need to create .nomedia manually',
+      'hideImagesInAlbumHints':
+          'If you changed default download path, you need to create .nomedia manually',
 
       /// read setting page
       'enableImmersiveMode': '몰입형 모드 사용',
@@ -473,12 +502,14 @@ class ko_KR {
       'portrait': 'Portrait',
       'readDirection': '읽는 방향',
       'enableOrientationSpecificReadDirection': '화면 방향별 읽기 방향',
-      'enableOrientationSpecificReadDirectionHint': '세로 및 가로 화면에 대해 서로 다른 읽기 방향을 설정합니다',
+      'enableOrientationSpecificReadDirectionHint':
+          '세로 및 가로 화면에 대해 서로 다른 읽기 방향을 설정합니다',
       'portraitReadDirection': '세로 화면 읽기 방향',
       'landscapeReadDirection': '가로 화면 읽기 방향',
       'autoSwitchedReadDirection': '읽기 방향 자동 전환됨',
       'notchOptimization': 'Notch Optimization',
-      'notchOptimizationHint': 'Add padding before the first image to avoid the notch and status bar',
+      'notchOptimizationHint':
+          'Add padding before the first image to avoid the notch and status bar',
       'imageRegionWidthRatio': 'Image Region Width Ratio',
       'portraitImageRegionWidthRatio': 'Portrait Image Width Ratio',
       'landscapeImageRegionWidthRatio': 'Landscape Image Width Ratio',
@@ -502,7 +533,8 @@ class ko_KR {
       'left2rightList': 'Left to Right (Continuous)',
       'right2leftList': 'Right to Left (Continuous)',
       'enablePageTurnByVolumeKeys': 'Use volume key to turn page',
-      'enablePageTurnByVolumeKeysHint': 'iOS에서 볼륨이 0 또는 100%일 때 읽기 페이지에 들어가면 페이지 넘기기를 위해 볼륨이 자동으로 조정되고, 나가면 복원됩니다',
+      'enablePageTurnByVolumeKeysHint':
+          'iOS에서 볼륨이 0 또는 100%일 때 읽기 페이지에 들어가면 페이지 넘기기를 위해 볼륨이 자동으로 조정되고, 나가면 복원됩니다',
       'enablePageTurnAnime': '페이지 넘기기 애니메이션 사용',
       'enableDoubleTapToScaleUp': '두 번 터치해 확대 사용',
       'enableTapDragToScaleUp': 'Enable Tap Drag to Scale up',
@@ -514,7 +546,8 @@ class ko_KR {
       'turnPageModeHint': '화면 기준 혹은 이미지 기준',
       'enableImageMaxKilobytes': 'Enable Image Compression',
       'imageMaxKilobytes': 'Image Max Size',
-      'imageMaxKilobytesHint': 'Images larger than this size will be compressed',
+      'imageMaxKilobytesHint':
+          'Images larger than this size will be compressed',
       'image': '이미지 기준',
       'screen': '화면 기준',
       'preloadDistanceInOnlineMode': 'Preload Distance(Online)',
@@ -522,6 +555,11 @@ class ko_KR {
       'ScreenHeight': 'Screen',
       'preloadPageCount': 'Preload Page Count(Online)',
       'preloadPageCountInLocalMode': 'Preload Page Count(Local)',
+      'failedImageRetryScope': "실패 이미지 재시도 범위",
+      'failedImageRetryScopeHint': "온라인 이미지 로드 실패 시 탭하여 재시도할 때 적용되는 범위",
+      'retrySingleImage': "현재 이미지만",
+      'retryCurrentPageAndAfter': "현재 이미지 및 이후",
+      'retryAllFailedImages': "모든 실패 이미지",
       'continuousScroll': '길게 이어진 스크롤',
       'continuousScrollHint': '여러 이미지가 가로로 연결됨',
       'doubleColumn': '두 쪽으로 보기',
@@ -588,8 +626,10 @@ class ko_KR {
       'reUnlock': '다시 잠금 해제',
       'reUnlockHint': '주의! 다시 잠금 해제하려면 이 파일을 다시 구입해야 합니다.',
       'downloadHelpInfo': '다운로드 할 수 없고 로그에 DB 테이블이 없다면 앱을 삭제하고 다시 설치하세요.',
-      'localGalleryHelpInfo': 'JHenTai에서 다운로드하지 않은 갤러리를 불러옵니다. 다운로드 설정 → 추가 갤러리 스캔 경로를 추가하고 새로고침하세요.',
-      'localGalleryHelpInfo4iOSAndMacOS': 'Load gallerys which is not downloaded by JHenTai. Put your gallerys in default download path and then refresh',
+      'localGalleryHelpInfo':
+          'JHenTai에서 다운로드하지 않은 갤러리를 불러옵니다. 다운로드 설정 → 추가 갤러리 스캔 경로를 추가하고 새로고침하세요.',
+      'localGalleryHelpInfo4iOSAndMacOS':
+          'Load gallerys which is not downloaded by JHenTai. Put your gallerys in default download path and then refresh',
       'deleteLocalGalleryHint': '사용자의 로컬 파일을 삭제합니다.',
       'priority': '우선순위',
       'highest': '높음',
@@ -616,11 +656,16 @@ class ko_KR {
       'multiReDownloadHint': 'You will re-download all selected gallerys.',
       'multiChangeGroupHint': 'You will change group of all selected gallerys.',
       'multiDeleteHint': 'You will delete all selected gallerys.',
-      'blankImageHint': 'Downloading the image returned an empty result, trying to re-parse.',
-      'peakHoursHint': 'Downloading original files during peak hours requires GP, and you do not have enough, downloading is paused.',
-      'oldGalleryHint': 'Downloading original files of this gallery requires GP, and you do not have enough.',
-      'exceedLimitHint': 'You have reached the image limit, and do not have sufficient GP to buy a download quota.',
-      'deleteUpdatingDependentHint': 'Another gallery\'s update relies on current gallery, you\'d better delete after update has completed.',
+      'blankImageHint':
+          'Downloading the image returned an empty result, trying to re-parse.',
+      'peakHoursHint':
+          'Downloading original files during peak hours requires GP, and you do not have enough, downloading is paused.',
+      'oldGalleryHint':
+          'Downloading original files of this gallery requires GP, and you do not have enough.',
+      'exceedLimitHint':
+          'You have reached the image limit, and do not have sufficient GP to buy a download quota.',
+      'deleteUpdatingDependentHint':
+          'Another gallery\'s update relies on current gallery, you\'d better delete after update has completed.',
       'migrateToDownload': 'Migrate To 「Download」',
       'refresh': 'Refresh',
 
@@ -704,7 +749,8 @@ class ko_KR {
 
       /// download setting page
       'downloadPath': '다운로드 경로',
-      'changeDownloadPathHint': '길게 눌러 변경(SD 카드 또는 시스템 경로는 사용하지 마세요). 다운로드한 갤러리를 자동으로 복사하고 오래된 파일은 보관합니다. 오류가 발생하면 초기화해 보세요.',
+      'changeDownloadPathHint':
+          '길게 눌러 변경(SD 카드 또는 시스템 경로는 사용하지 마세요). 다운로드한 갤러리를 자동으로 복사하고 오래된 파일은 보관합니다. 오류가 발생하면 초기화해 보세요.',
       'resetDownloadPath': '다운로드 경로 초기화',
       'extraGalleryScanPath': '추가 갤러리 스캔 경로',
       'extraGalleryScanPathHint': '로컬 갤러리를 스캔하고 불러오기 위함',
@@ -729,15 +775,19 @@ class ko_KR {
       'per': '/ 시간: ',
       'images': '장 ',
       'downloadTimeout': '다운로드 시간 초과',
-      'downloadAllGallerysOfSamePriority': 'Download All Gallerys of Same Priority',
-      'downloadAllGallerysOfSamePriorityHint': 'Download only 1 gallery simultaneously in 1 group with highest priority by default',
+      'downloadAllGallerysOfSamePriority':
+          'Download All Gallerys of Same Priority',
+      'downloadAllGallerysOfSamePriorityHint':
+          'Download only 1 gallery simultaneously in 1 group with highest priority by default',
       'alwaysUseDefaultGroup': '항상 기본 그룹 사용',
       'enableStoreMetadataForRestore': '복원을 위한 저장소 메타데이터 사용',
       'enableStoreMetadataForRestoreHint': '사용하지 않으면 다운로드 작업을 복원할 수 없습니다.',
       'archiveDownloadIsolateCount': 'Archive Download Thread Count',
-      'archiveDownloadIsolateCountHint': 'Sum of threads for all tasks needs to be less than 10, otherwise the download will fail',
+      'archiveDownloadIsolateCountHint':
+          'Sum of threads for all tasks needs to be less than 10, otherwise the download will fail',
       'manageArchiveDownloadConcurrency': 'Manage Archive Download Concurrency',
-      'manageArchiveDownloadConcurrencyHint': 'Archive will wait until there are enough threads to download',
+      'manageArchiveDownloadConcurrencyHint':
+          'Archive will wait until there are enough threads to download',
       'deleteArchiveFileAfterDownload': '다운로드 완료 후 아카이브 .zip 파일 삭제',
       'restoreDownloadTasks': '다운로드 작업 복원',
       'restoreDownloadTasksHint': '메타데이터로 다운로드 작업 복원',
@@ -746,9 +796,11 @@ class ko_KR {
       'restoredGalleryCount': '복원된 갤러리 수',
       'restoredArchiveCount': '복원된 아카이브 수',
       'restoreTasksAutomatically': 'Restore Tasks Automatically',
-      'restoreTasksAutomaticallyHint': 'Restore tasks automatically when app launched',
+      'restoreTasksAutomaticallyHint':
+          'Restore tasks automatically when app launched',
       'brokenDownloadPathHint': '다운로드 경로가 손상된 것 같습니다. 다운로드 기능이 낮아질 수 있습니다.',
-      'brokenExtraScanPathHint': 'Seems your default local gallery path is broken, local gallery may be not recognized',
+      'brokenExtraScanPathHint':
+          'Seems your default local gallery path is broken, local gallery may be not recognized',
       'useJH2UpdateGallery': 'Use JH server to accelerate gallery updates',
 
       /// archive bot settings
@@ -765,7 +817,8 @@ class ko_KR {
       'checkInFailed': 'Check-in failed',
       'checkInSuccess': 'Check-in success',
       'checkInSuccessHint': 'Got GP: %s, current total GP: %s.',
-      'pauseDownloadByInvalidArchiveBotKey': 'Archive bot settings is invalid, download paused',
+      'pauseDownloadByInvalidArchiveBotKey':
+          'Archive bot settings is invalid, download paused',
       'chooseArchiveParseSource': 'Change Parse Source',
       'official': 'Official',
       'archiveBot': 'Archive Bot',
@@ -794,7 +847,8 @@ class ko_KR {
       'upload2cloud': 'Upload to Cloud',
       'upload2cloudHint': 'Upload your current local configuration',
       'tap2upload': 'Tap to upload',
-      'copyIdentificationCodeSuccess': 'Upload successfully. Identification code has been copied',
+      'copyIdentificationCodeSuccess':
+          'Upload successfully. Identification code has been copied',
       'copyShareCode': 'Copy Share Code',
       'import': 'Import',
       'save2Local': 'Save to Local',
@@ -810,9 +864,11 @@ class ko_KR {
       'inputNumberHint': 'Please input a correct number',
       'inputRegexHint': 'Please input a correct regex',
       'useBuiltInBlockedUsers': 'Enable Built-in User Blocklist',
-      'useBuiltInBlockedUsersHint': 'Filter out gallery comments from users on the blocklist',
+      'useBuiltInBlockedUsersHint':
+          'Filter out gallery comments from users on the blocklist',
       'blockingRules': 'Block Rules',
-      'blockingRulesHint': 'Additional blocking rules for gallerys and comments',
+      'blockingRulesHint':
+          'Additional blocking rules for gallerys and comments',
       'blockingTarget': 'Blocking Target',
       'blockingAttribute': 'Blocking Attribute',
       'blockingPattern': 'Blocking Pattern',
@@ -826,7 +882,8 @@ class ko_KR {
       'content': 'Content',
       'incompleteInformation': 'Incomplete information',
       'noBlockingRuleHint': 'Add at least 1 rule',
-      'notSameBlockingRuleTargetHint': 'All sub-rules should have the same blocking target',
+      'notSameBlockingRuleTargetHint':
+          'All sub-rules should have the same blocking target',
       'blockingRuleHelp': '''
 Blocking Target: Filter galleries on the list page or filter comments on the details page. All sub-rules under the same rule must have the same blocking target.
 Blocking Attribute: Specify the attribute of the target based on which the rule is written to block.

--- a/lib/src/l18n/ko_KR.dart
+++ b/lib/src/l18n/ko_KR.dart
@@ -323,6 +323,7 @@ class ko_KR {
       'light': '밝은 모드',
       'followSystem': '시스템에 따라',
       'themeColor': '테마 색상',
+      'themeColorFixedOnApple': 'macOS / iOS에서 고정 강조색 사용',
       'listStyle': '갤러리 리스트 스타일 (기본값)',
       'flat': '플랫',
       'flatWithoutTags': '플랫(태그 없음)',

--- a/lib/src/l18n/pt_BR.dart
+++ b/lib/src/l18n/pt_BR.dart
@@ -324,6 +324,7 @@ class pt_BR {
       'light': 'Claro',
       'followSystem': 'Seguir o sistema',
       'themeColor': 'Theme Color',
+      'themeColorFixedOnApple': 'Cor de destaque fixa no macOS / iOS',
       'listStyle': 'Estilo da lista da galeria',
       'flat': 'Reto',
       'flatWithoutTags': 'Reto(Sem tags)',

--- a/lib/src/l18n/pt_BR.dart
+++ b/lib/src/l18n/pt_BR.dart
@@ -35,7 +35,8 @@ class pt_BR {
       'archiveError': 'Download Archive Error',
       'edit': 'Edit',
       'confirmDestructiveActions': 'Confirmar ações destrutivas',
-      'confirmDestructiveActionsHint': 'Mostrar um diálogo de confirmação antes de ações destrutivas, como excluir tarefas ou baixar novamente na página de downloads',
+      'confirmDestructiveActionsHint':
+          'Mostrar um diálogo de confirmação antes de ações destrutivas, como excluir tarefas ou baixar novamente na página de downloads',
 
       'home': "Home",
       'gallery': "Galeria",
@@ -78,7 +79,8 @@ class pt_BR {
       'userName': 'Nome de usuário',
       'EHUser': 'Usuário EH',
       'password': 'Senha',
-      'needCaptcha': 'Precisa do captcha, por favor fassa login via cookie ou pela web de novo.',
+      'needCaptcha':
+          'Precisa do captcha, por favor fassa login via cookie ou pela web de novo.',
       'userNameOrPasswordMismatch': 'Nome de usuáriio e/ou senha incorreto(s)',
       'copyCookies': 'Copiar cookies',
       'tap2Copy': 'Toque para copiar',
@@ -91,8 +93,10 @@ class pt_BR {
       'refreshIgneousFailed': 'Refresh Igneous Failed',
 
       /// request
-      'sadPanda': 'Sad Panda(no data). Refer: https://github.com/jiangtian616/JHenTai/wiki/Common-Questions',
-      'sadPandaReferLink': 'https://github.com/jiangtian616/JHenTai/wiki/Common-Questions',
+      'sadPanda':
+          'Sad Panda(no data). Refer: https://github.com/jiangtian616/JHenTai/wiki/Common-Questions',
+      'sadPandaReferLink':
+          'https://github.com/jiangtian616/JHenTai/wiki/Common-Questions',
 
       /// gallery card
       'filtered': 'Filtered',
@@ -104,7 +108,8 @@ class pt_BR {
       'jumpPageTo': 'Pular para à página',
       'range': 'Alcance',
       'current': 'Atual',
-      'galleryUrlDetected': 'URL de galeria encontrada na área de transferência',
+      'galleryUrlDetected':
+          'URL de galeria encontrada na área de transferência',
       'galleryUrlDetectedHint': 'Toque para entrar na página de detalhes',
 
       /// details page
@@ -131,10 +136,12 @@ class pt_BR {
       'noComments': 'Sem comentários',
       'lastEditedOn': 'Última edição em',
       'getGalleryDetailFailed': 'Falha ao obter detalhes da galeria',
-      'cloudflare403': 'You have been restricted by Cloudflare from making network requests. Please try switching networks or using another login method.',
+      'cloudflare403':
+          'You have been restricted by Cloudflare from making network requests. Please try switching networks or using another login method.',
       'invisible2User': 'Esta Galeria é invisível para você',
       'invisibleHints': 'Esta galeria está indisponível ou foi removida.',
-      'copyRightHints': 'Esta galeria está indisponível devido a uma reivindicação de direitos autorais por ',
+      'copyRightHints':
+          'Esta galeria está indisponível devido a uma reivindicação de direitos autorais por ',
       'refreshGalleryDetailsFailed': 'Falha ao atualizar detalhes da galeria',
       'failToGetThumbnails': "Falha ao obter miniaturas",
       'favoriteGallerySuccess': "Favorite Gallery Success",
@@ -142,7 +149,8 @@ class pt_BR {
       'removeFavoriteSuccess': "Remove Favorite Success",
       'removeFavoriteFailed': "Remove Favorite Failed",
       'getGalleryFavoriteInfoFailed': 'Get gallery favorite info failed',
-      'favoriteNoteSlotFullHint': 'Favorite note slot is full, please delete some notes first',
+      'favoriteNoteSlotFullHint':
+          'Favorite note slot is full, please delete some notes first',
       'ratingSuccess': 'Rating Success',
       'ratingFailed': 'Falha na avaliação',
       'voteTagFailed': 'Falha na tag de votação',
@@ -150,12 +158,16 @@ class pt_BR {
       'resumeDownload': 'Retomar',
       'pauseDownload': 'Pausar',
       'addNewTagSetSuccess': 'Novo conjunto de tags adicionado com sucesso',
-      'addNewWatchedTagSetSuccess': 'Novo conjunto de tags adicionado com sucesso',
-      'addNewHiddenTagSetSuccess': 'Novo conjunto de tags ocultas adicionado com sucesso',
-      'addNewTagSetSuccessHint': 'Você pode verificar suas tags em Configurações->EH->My Tags',
+      'addNewWatchedTagSetSuccess':
+          'Novo conjunto de tags adicionado com sucesso',
+      'addNewHiddenTagSetSuccess':
+          'Novo conjunto de tags ocultas adicionado com sucesso',
+      'addNewTagSetSuccessHint':
+          'Você pode verificar suas tags em Configurações->EH->My Tags',
       'addNewTagSetFailed': 'Falha ao adicionar novo conjunto de tags',
       'VisitorStatistics': 'Estatísticas do visitante',
-      'invisible2UserWithoutDonation': 'As estatísticas desta galeria são invisíveis para os usuários sem doação',
+      'invisible2UserWithoutDonation':
+          'As estatísticas desta galeria são invisíveis para os usuários sem doação',
       'getGalleryStatisticsFailed': 'Falha ao obter estatísticas da galeria',
       'totalVisits': 'Total de visitas',
       'visits': 'Visitas',
@@ -165,23 +177,29 @@ class pt_BR {
       'score': 'Pontuação',
       'NotOnTheList': 'Não está na lista',
       'getGalleryArchiveFailed': 'Falha ao obter arquivo da galeria',
-      'parseGalleryArchiveFailed': 'Falha na análise, certifique-se de que seu [Archiver Settings] em e-hentai é [Manual Select, Manual Start (Default)]',
+      'parseGalleryArchiveFailed':
+          'Falha na análise, certifique-se de que seu [Archiver Settings] em e-hentai é [Manual Select, Manual Start (Default)]',
       'original': 'Original',
       'resample': 'Redimensionamento',
       'beginToDownloadArchive': 'Começar a baixar o arquivo',
-      'beginToDownloadArchiveHint': 'Você pode verificar o progresso em Baixar -> Arquivo',
+      'beginToDownloadArchiveHint':
+          'Você pode verificar o progresso em Baixar -> Arquivo',
       'updateGalleryError': 'Erro ao atualizar galeria',
       'thisGalleryHasANewVersion': 'Nova versão desta galeria disponível',
       'hasUpdated': 'Atualizado',
       'unpackingArchiveError': 'Unpacking archive error',
       'failedToDealWith': 'Falha ao lidar com',
       'hasDownloaded': 'Baixado',
-      '410Hints': 'Você registrou muitos bytes baixados neste arquivo e precisa desbloquear novamente este arquivo para continuar.',
-      '429Hints': 'Too many download requests! You\'d better decrease your archive download concurrency.',
-      'getUnpackedImagesFailedMsg': 'JHenTai não pode carregar imagens deste arquivo, por favor verifique seu arquivo local.',
+      '410Hints':
+          'Você registrou muitos bytes baixados neste arquivo e precisa desbloquear novamente este arquivo para continuar.',
+      '429Hints':
+          'Too many download requests! You\'d better decrease your archive download concurrency.',
+      'getUnpackedImagesFailedMsg':
+          'JHenTai não pode carregar imagens deste arquivo, por favor verifique seu arquivo local.',
       'getGalleryTorrentsFailed': 'Falha ao obter torrents',
       'chooseArchive': 'Escolher Arquivo',
-      'tagSetExceedLimit': 'No more tags can be added because you have reach the limit',
+      'tagSetExceedLimit':
+          'No more tags can be added because you have reach the limit',
       'useTranslation': 'Use Translation',
       'addTagSuccess': 'Add Tag Success',
       'addTagFailed': 'Add Tag Failed',
@@ -205,7 +223,8 @@ class pt_BR {
       'commentTooShort': 'O comentário é muito curto',
       'sendCommentFailed': 'Falha ao enviar comentário',
       'voteCommentFailed': 'Falha ao votar cometário',
-      'voteCommentFailedHint': 'Tente puxar para baixo para atualizar a página de detalhes primeiro',
+      'voteCommentFailedHint':
+          'Tente puxar para baixo para atualizar a página de detalhes primeiro',
       'unknownUser': 'Usuário desconhecido',
       'atLeast3Characters': 'Pelo menos 3 caracteres',
       'noJHenTaiHints': 'Please don\'t mention JHenTai, thanks',
@@ -222,8 +241,10 @@ class pt_BR {
       'loading': "Caregando",
       'paused': 'Pausar',
       'exceedImageLimits': "Limite de imagens excedido",
-      'ehServerError': 'An error occurred due to EH\'s server, please try again later',
-      'unsupportedImagePageStyle': "JHenTai não suporta Multi-Page Viewer (MPV), por favor mude para o estilo padrão em e-hentai.org",
+      'ehServerError':
+          'An error occurred due to EH\'s server, please try again later',
+      'unsupportedImagePageStyle':
+          "JHenTai não suporta Multi-Page Viewer (MPV), por favor mude para o estilo padrão em e-hentai.org",
       'toNext': 'Para o próximo',
       'toPrev': 'Para anterior',
       'back': 'Voltar',
@@ -260,9 +281,11 @@ class pt_BR {
       /// eh setting page
       'site': 'Site',
       'redirect2Eh': 'Redirecionar para EH, se disponível',
-      'redirect2EhHint': 'Try to load gallery detail page from EH site first to get better network performance',
+      'redirect2EhHint':
+          'Try to load gallery detail page from EH site first to get better network performance',
       'redirectAllGallery': 'Redirect all gallery to EH',
-      'imDonorHint': 'If you are a donor, you can turn this on to help you access gallerys in EX site',
+      'imDonorHint':
+          'If you are a donor, you can turn this on to help you access gallerys in EX site',
       'profileSetting': 'Profile Setting',
       'chooseProfileHint': 'Choose profile used in JHenTai',
       'siteSetting': 'Configuração do site',
@@ -311,20 +334,25 @@ class pt_BR {
       'tabletLayoutName': 'Tablet(antigo)',
       'tabletLayoutDesc': 'Manutenção interrompida',
       'desktopLayoutName': 'Desktop',
-      'desktopLayoutDesc': 'Duas colunas com barra de abas na esquerda, suporte a teclado',
+      'desktopLayoutDesc':
+          'Duas colunas com barra de abas na esquerda, suporte a teclado',
 
       /// style setting page
       'enableTagZHTranslation': 'Traduzir nome da tag para Chinês',
       'version': 'Versão',
       'downloadTagTranslationHint': 'Baixando dados..., baixado: ',
-      'zhTagSearchOrderOptimization': 'Chinese Tag Auto-Completion Ordering Rule',
-      'zhTagSearchOrderOptimizationHint': 'Intelligent sorting by default and sort by frequency if enabled',
+      'zhTagSearchOrderOptimization':
+          'Chinese Tag Auto-Completion Ordering Rule',
+      'zhTagSearchOrderOptimizationHint':
+          'Intelligent sorting by default and sort by frequency if enabled',
       'themeMode': 'Tema',
       'dark': 'Escuro',
       'light': 'Claro',
       'followSystem': 'Seguir o sistema',
       'themeColor': 'Theme Color',
       'themeColorFixedOnApple': 'Cor de destaque fixa no macOS / iOS',
+      'appleVisualStyle': 'Estilo visual Apple',
+      'appleVisualStyleHint': 'Ativar a interface redesenhada no macOS e iOS',
       'listStyle': 'Estilo da lista da galeria',
       'flat': 'Reto',
       'flatWithoutTags': 'Reto(Sem tags)',
@@ -335,8 +363,10 @@ class pt_BR {
       'waterfallFlowBig': 'Waterfall Flow (Big)',
       'crossAxisCountInWaterFallFlow': 'Waterfall Flow Column count',
       'pageListStyle': 'Gallery List Style (Page)',
-      'crossAxisCountInGridDownloadPageForGroup': 'Download Page Grid Column Count(Group)',
-      'crossAxisCountInGridDownloadPageForGallery': 'Download Page Grid Column Count(Gallery)',
+      'crossAxisCountInGridDownloadPageForGroup':
+          'Download Page Grid Column Count(Group)',
+      'crossAxisCountInGridDownloadPageForGallery':
+          'Download Page Grid Column Count(Gallery)',
       'crossAxisCountInDetailPage': 'Detail Page Thumbnail Column Count',
       'global': 'Global',
       'auto': 'Auto',
@@ -351,12 +381,15 @@ class pt_BR {
       'whenScrollUp': 'When Scroll Up',
       'whenScrollDown': 'When Scroll Down',
       'preloadGalleryCover': 'Preload gallery cover',
-      'preloadGalleryCoverHint': 'Preload the covers of galleries that are not yet displayed on the page',
+      'preloadGalleryCoverHint':
+          'Preload the covers of galleries that are not yet displayed on the page',
       'enableSwipeBackGesture': 'Enable Swipe Back Gesture',
       'enableLeftMenuDrawerGesture': 'Enable Left Menu Drawer Gesture',
-      'enableQuickSearchDrawerGesture': 'Ativar pesquisa rápida com gesto de gaveta',
+      'enableQuickSearchDrawerGesture':
+          'Ativar pesquisa rápida com gesto de gaveta',
       'drawerGestureEdgeWidth': 'Drawer Gesture Edge Width',
-      'alwaysShowScroll2TopButton': 'Sempre mostrar o botão de rolagem para cima',
+      'alwaysShowScroll2TopButton':
+          'Sempre mostrar o botão de rolagem para cima',
       'enableDefaultFavorite': 'Enable Default Favorite',
       'enableDefaultFavoriteHint': 'Long press to re-select',
       'enableDefaultTagSet': 'Enable Default Tag Set',
@@ -369,28 +402,35 @@ class pt_BR {
       'inheritAll': 'Inherit All',
       'inheritAllHint': 'Use last search options for next search',
       'inheritPartially': 'Inherit Partially',
-      'inheritPartiallyHint': 'Use last search options for next search(except language and category)',
+      'inheritPartiallyHint':
+          'Use last search options for next search(except language and category)',
       'none': 'None',
       'noneHint': 'Use default search options for next search',
       'showAllGalleryTitles': 'Show All Gallery Titles',
-      'showAllGalleryTitlesHint': 'Show both original and japanese titles if available',
+      'showAllGalleryTitlesHint':
+          'Show both original and japanese titles if available',
       'showGalleryTagVoteStatus': 'Show Gallery Tag Vote Status',
-      'showGalleryTagVoteStatusHint': 'Include confidence, skepticism and incorrect',
+      'showGalleryTagVoteStatusHint':
+          'Include confidence, skepticism and incorrect',
       'showComments': 'Show Comments',
       'showAllComments': 'Show All Comments',
-      'showAllCommentsHint': 'By default only the 45 highest scoring and 5 most recent comments will be shown',
+      'showAllCommentsHint':
+          'By default only the 45 highest scoring and 5 most recent comments will be shown',
       'addTag': 'Add Tag',
       'addTagHint': 'Enter new tags, separated with comma',
 
       /// theme color setting page
-      'themeColorSettingHint': 'Assign different color for light and dark theme',
+      'themeColorSettingHint':
+          'Assign different color for light and dark theme',
       'preview': 'Preview',
       'preset': 'Preset',
       'custom': 'Custom',
 
       /// performance setting page
-      'maxGalleryNum4Animation': 'Max Gallery Num For List Animation in Download page',
-      'maxGalleryNum4AnimationHint': 'Disable animation for groups which have more gallerys than this value(for list style)',
+      'maxGalleryNum4Animation':
+          'Max Gallery Num For List Animation in Download page',
+      'maxGalleryNum4AnimationHint':
+          'Disable animation for groups which have more gallerys than this value(for list style)',
 
       /// mouse wheel setting page
       'wheelScrollSpeed': 'Velocidade de rolagem',
@@ -402,7 +442,8 @@ class pt_BR {
       'hostMapping': 'Mapeamento de host',
       'hostMappingHint': 'Usado para frente de domínio',
       'proxyAddress': 'Endereço de proxy',
-      'proxyAddressHint': 'Se você usa servidor proxy, certifique-se de configurá-lo corretamente',
+      'proxyAddressHint':
+          'Se você usa servidor proxy, certifique-se de configurá-lo corretamente',
       'saveSuccess': 'Salvo com sucesso',
       'saveFailed': 'Save failed',
       'updateSuccess': 'Atualizado com sucesso',
@@ -411,7 +452,8 @@ class pt_BR {
       'pageCacheMaxAge': 'Idade máxima do cache de página',
       'pageCacheMaxAgeHint': 'Você pode atualizar o cache atualizando a página',
       'cacheImageExpireDuration': 'Image Cache Expiration Time',
-      'cacheImageExpireDurationHint': 'Remove image cache automatically after launching app',
+      'cacheImageExpireDurationHint':
+          'Remove image cache automatically after launching app',
       'oneMinute': '1 Minuto',
       'tenMinute': '10 Minutos',
       'oneHour': '1 Hora',
@@ -424,24 +466,29 @@ class pt_BR {
       'clearImagesCache': 'Limpar cache de imagens',
       'longPress2Clear': 'Pressione e segure para limpar',
       'checkUpdateAfterLaunchingApp': 'Buscar atualizações após abrir o app',
-      'checkClipboard': 'Verificar se há URL de Galeria na área de transferência',
+      'checkClipboard':
+          'Verificar se há URL de Galeria na área de transferência',
       'clearPageCache': 'Limpar cache de página',
       'clearSuccess': 'Limpado com Sucesso',
       'superResolution': 'Image Super Resolution',
       'stopSuperResolution': 'Stop Super Resolution',
       'deleteSuperResolvedImage': 'Delete Super Resolved Image',
-      'superResolveOriginalImageHint': 'Process original image cost more time, space and performance, are you sure to continue?',
+      'superResolveOriginalImageHint':
+          'Process original image cost more time, space and performance, are you sure to continue?',
       'verityAppLinks4Android12': 'Verity App Links(Android 12+)',
-      'verityAppLinks4Android12Hint': 'For Android 12+, you need to manually add link to verified links in order to open JHenTai in 3-rd apps',
+      'verityAppLinks4Android12Hint':
+          'For Android 12+, you need to manually add link to verified links in order to open JHenTai in 3-rd apps',
       'noImageMode': 'No Image Mode',
       'exportData': 'Export Data',
       'exportDataHint': 'Export configs, block rules and history',
       'selectExportItems': 'Select Export Items',
       'importData': 'Import Data',
-      'importDataHint': 'App will shutdown automatically after importing to apply the latest configuration',
+      'importDataHint':
+          'App will shutdown automatically after importing to apply the latest configuration',
 
       /// host mapping page
-      'hostDataSource': 'Não há necessidade de alterar por padrão.\nFonte de dados: https://dns.google/',
+      'hostDataSource':
+          'Não há necessidade de alterar por padrão.\nFonte de dados: https://dns.google/',
 
       /// proxy page
       'proxySetting': 'Proxy Setting',
@@ -458,9 +505,11 @@ class pt_BR {
       'enableBiometricAuth': 'Ativar autenticação biométrica',
       'enableAuthOnResume': 'Enable Auth on Resume',
       'enableAuthOnResumeHints': '3 segundos de atraso',
-      'enableBlurBackgroundApp': 'Ative a página de desfoque ao alternar para o plano de fundo',
+      'enableBlurBackgroundApp':
+          'Ative a página de desfoque ao alternar para o plano de fundo',
       'hideImagesInAlbum': 'Hide Images in Album',
-      'hideImagesInAlbumHints': 'If you changed default download path, you need to create .nomedia manually',
+      'hideImagesInAlbumHints':
+          'If you changed default download path, you need to create .nomedia manually',
 
       /// read setting page
       'enableImmersiveMode': 'Habilitar modo imersivo',
@@ -473,19 +522,24 @@ class pt_BR {
       'landscape': 'Landscape',
       'portrait': 'Portrait',
       'readDirection': 'Direção da leitura',
-      'enableOrientationSpecificReadDirection': 'Direção de leitura por orientação',
-      'enableOrientationSpecificReadDirectionHint': 'Definir direções de leitura diferentes para orientações retrato e paisagem',
+      'enableOrientationSpecificReadDirection':
+          'Direção de leitura por orientação',
+      'enableOrientationSpecificReadDirectionHint':
+          'Definir direções de leitura diferentes para orientações retrato e paisagem',
       'portraitReadDirection': 'Direção de leitura (retrato)',
       'landscapeReadDirection': 'Direção de leitura (paisagem)',
-      'autoSwitchedReadDirection': 'Direção de leitura alterada automaticamente',
+      'autoSwitchedReadDirection':
+          'Direção de leitura alterada automaticamente',
       'notchOptimization': 'Notch Optimization',
-      'notchOptimizationHint': 'Add padding before the first image to avoid the notch and status bar',
+      'notchOptimizationHint':
+          'Add padding before the first image to avoid the notch and status bar',
       'imageRegionWidthRatio': 'Image Region Width Ratio',
       'portraitImageRegionWidthRatio': 'Portrait Image Width Ratio',
       'landscapeImageRegionWidthRatio': 'Landscape Image Width Ratio',
       'gestureRegionWidthRatio': 'Gesture Region Width Ratio',
       'useThirdPartyViewer': 'Usar visualizador personaliado',
-      'thirdPartyViewerPath': 'Localização do visualizador personalizado(Arquivo executável)',
+      'thirdPartyViewerPath':
+          'Localização do visualizador personalizado(Arquivo executável)',
       'showThumbnails': 'Mostrar miniaturas',
       'showScrollBar': 'Show Scroll Bar',
       'showStatusInfo': 'Mostrar status na parte inferior',
@@ -503,7 +557,8 @@ class pt_BR {
       'left2rightList': 'Left to Right (Continuous)',
       'right2leftList': 'Right to Left (Continuous)',
       'enablePageTurnByVolumeKeys': 'Use volume key to turn page',
-      'enablePageTurnByVolumeKeysHint': 'No iOS, se o volume estiver em 0 ou 100%, ele será ajustado automaticamente ao entrar no leitor para suportar a virada de página e restaurado ao sair',
+      'enablePageTurnByVolumeKeysHint':
+          'No iOS, se o volume estiver em 0 ou 100%, ele será ajustado automaticamente ao entrar no leitor para suportar a virada de página e restaurado ao sair',
       'enablePageTurnAnime': 'Ativar animação de virada',
       'enableDoubleTapToScaleUp': 'Ativar toque duplo para aumentar a escala',
       'enableTapDragToScaleUp': 'Enable Tap Drag to Scale up',
@@ -515,7 +570,8 @@ class pt_BR {
       'turnPageModeHint': 'Para a próxima tela ou próxima imagem',
       'enableImageMaxKilobytes': 'Enable Image Compression',
       'imageMaxKilobytes': 'Image Max Size',
-      'imageMaxKilobytesHint': 'Images larger than this size will be compressed',
+      'imageMaxKilobytesHint':
+          'Images larger than this size will be compressed',
       'image': 'Imagem',
       'screen': 'Tela',
       'preloadDistanceInOnlineMode': 'Preload Distance(Online)',
@@ -523,6 +579,12 @@ class pt_BR {
       'ScreenHeight': 'Screen',
       'preloadPageCount': 'Preload Page Count(Online)',
       'preloadPageCountInLocalMode': 'Preload Page Count(Local)',
+      'failedImageRetryScope': "Escopo de repetição de imagens com falha",
+      'failedImageRetryScopeHint':
+          "Escopo ao tocar em uma imagem online com falha para recarregá-la",
+      'retrySingleImage': "Apenas a imagem tocada",
+      'retryCurrentPageAndAfter': "Imagem atual e seguintes",
+      'retryAllFailedImages': "Todas as imagens com falha",
       'continuousScroll': 'Rolagem contínua',
       'continuousScrollHint': 'Junte várias imagens',
       'doubleColumn': 'Duas Colunas',
@@ -532,7 +594,8 @@ class pt_BR {
       'landscapeDisplayFirstPageAlone': 'Landscape Display First Page Alone',
       'toggleFullScreen': 'Toggle Full Screen',
       'keyboardShortcuts': 'Atalhos de Teclado',
-      'keyboardShortcutsHint': 'Personalizar atalhos de teclado da página de leitura',
+      'keyboardShortcutsHint':
+          'Personalizar atalhos de teclado da página de leitura',
       'pressAnyKey': 'Pressione qualquer tecla...',
       'unboundKey': 'Sem vínculo',
       'clearKey': 'Limpar',
@@ -540,13 +603,16 @@ class pt_BR {
       'resetSuccess': 'Redefinido para padrão',
       'keyConflict': 'Conflito de tecla',
       'fixedKeyHint': 'Tecla fixa, não personalizável',
-      'pressAnyKeyOrMouseSideButton': 'Pressione qualquer tecla ou botão lateral do mouse...',
+      'pressAnyKeyOrMouseSideButton':
+          'Pressione qualquer tecla ou botão lateral do mouse...',
       'mouseButton4Name': 'Mouse Avançar',
       'mouseButton5Name': 'Mouse Voltar',
       'toLeft': 'Virar à esquerda',
       'toRight': 'Virar à direita',
-      'enableAutoScaleUp': 'Ativar dimensionamento automático de imagens grandes',
-      'enableAutoScaleUpHints': 'Tornar a largura da imagem igual à largura da tela',
+      'enableAutoScaleUp':
+          'Ativar dimensionamento automático de imagens grandes',
+      'enableAutoScaleUpHints':
+          'Tornar a largura da imagem igual à largura da tela',
 
       /// preference setting page
       'showR18GImageDirectly': 'Show R18G Image Directly',
@@ -587,10 +653,14 @@ class pt_BR {
       'completed': 'Completo',
       'needReUnlock': 'Precisa de novo desbloqueio',
       'reUnlock': 'Desbloquear novamente',
-      'reUnlockHint': 'Atenção! precisa comprar este arquivo novamente para desbloque-lo novamente.',
-      'downloadHelpInfo': 'Se você não conseguir fazer o download e encontrar erros como a tabela não existe nos logs, desinstale o aplicativo atual e reinstale.',
-      'localGalleryHelpInfo': 'Load gallerys which is not downloaded by JHenTai. Add config in Download Setting -> Extra Gallery Scan Path and then refresh.',
-      'localGalleryHelpInfo4iOSAndMacOS': 'Load gallerys which is not downloaded by JHenTai. Put your gallerys in default download path and then refresh',
+      'reUnlockHint':
+          'Atenção! precisa comprar este arquivo novamente para desbloque-lo novamente.',
+      'downloadHelpInfo':
+          'Se você não conseguir fazer o download e encontrar erros como a tabela não existe nos logs, desinstale o aplicativo atual e reinstale.',
+      'localGalleryHelpInfo':
+          'Load gallerys which is not downloaded by JHenTai. Add config in Download Setting -> Extra Gallery Scan Path and then refresh.',
+      'localGalleryHelpInfo4iOSAndMacOS':
+          'Load gallerys which is not downloaded by JHenTai. Put your gallerys in default download path and then refresh',
       'deleteLocalGalleryHint': 'Delete your local files',
       'priority': 'Prioridade',
       'highest': 'Alta',
@@ -617,11 +687,16 @@ class pt_BR {
       'multiReDownloadHint': 'You will re-download all selected gallerys.',
       'multiChangeGroupHint': 'You will change group of all selected gallerys.',
       'multiDeleteHint': 'You will delete all selected gallerys.',
-      'blankImageHint': 'Downloading the image returned an empty result, trying to re-parse.',
-      'peakHoursHint': 'Downloading original files during peak hours requires GP, and you do not have enough, downloading is paused.',
-      'oldGalleryHint': 'Downloading original files of this gallery requires GP, and you do not have enough.',
-      'exceedLimitHint': 'You have reached the image limit, and do not have sufficient GP to buy a download quota.',
-      'deleteUpdatingDependentHint': 'Another gallery\'s update relies on current gallery, you\'d better delete after update has completed.',
+      'blankImageHint':
+          'Downloading the image returned an empty result, trying to re-parse.',
+      'peakHoursHint':
+          'Downloading original files during peak hours requires GP, and you do not have enough, downloading is paused.',
+      'oldGalleryHint':
+          'Downloading original files of this gallery requires GP, and you do not have enough.',
+      'exceedLimitHint':
+          'You have reached the image limit, and do not have sufficient GP to buy a download quota.',
+      'deleteUpdatingDependentHint':
+          'Another gallery\'s update relies on current gallery, you\'d better delete after update has completed.',
       'migrateToDownload': 'Migrate To 「Download」',
       'refresh': 'Refresh',
 
@@ -662,7 +737,8 @@ class pt_BR {
       'pageAtLeast': 'Página no mínimo',
       'pageAtMost': 'Página no máximo',
       'pagesBetween': 'Páginas entre',
-      'pageRangeSelectHint': 'min <= 1000, max >= 10\nmin/max <= 0.8, max-min >= 20',
+      'pageRangeSelectHint':
+          'min <= 1000, max >= 10\nmin/max <= 0.8, max-min >= 20',
       'to': 'para',
       'minimumRating': 'Classificação mínima',
       'disableFilterForLanguage': 'Desativar filtro para idioma',
@@ -685,7 +761,8 @@ class pt_BR {
       'getSomeOfGallerysFailed': 'Falha ao obter algumas das galerias',
 
       /// history page
-      'getHistoryGallerysFailed': 'Falha ao obter alguns dos histórico galerias',
+      'getHistoryGallerysFailed':
+          'Falha ao obter alguns dos histórico galerias',
 
       /// search page
       'search': 'Pesquisar',
@@ -716,14 +793,17 @@ class pt_BR {
       'originalImage': 'Original',
       'resampleImage': 'Redimensionada',
       'defaultGalleryGroup': 'Default Gallery Group',
-      'prioritizeRecentGalleryGroups': 'Priorizar grupos de galeria usados recentemente',
+      'prioritizeRecentGalleryGroups':
+          'Priorizar grupos de galeria usados recentemente',
       'defaultArchiveGroup': 'Default Archive Group',
       'never': 'Nunca',
       'manual': 'Manual',
       'always': 'Sempre',
       'longPress2Reset': 'Pressione e segure para redefinir',
-      'needPermissionToChangeDownloadPath': 'Precisa de permissão para alterar o caminho de download',
-      'invalidPath': 'Caminho inválido. Evite usar o caminho do sistema, caminho raiz ou caminho do cartão SD.',
+      'needPermissionToChangeDownloadPath':
+          'Precisa de permissão para alterar o caminho de download',
+      'invalidPath':
+          'Caminho inválido. Evite usar o caminho do sistema, caminho raiz ou caminho do cartão SD.',
       'downloadTaskConcurrency': 'Download simultâneo',
       'needRestart': 'Precisa reiniciar',
       'speedLimit': 'Limite de velocidade',
@@ -731,26 +811,37 @@ class pt_BR {
       'per': 'por',
       'images': 'imagens',
       'downloadTimeout': 'Tempo limite de download',
-      'downloadAllGallerysOfSamePriority': 'Download All Gallerys of Same Priority',
-      'downloadAllGallerysOfSamePriorityHint': 'Download only 1 gallery simultaneously in 1 group with highest priority by default',
+      'downloadAllGallerysOfSamePriority':
+          'Download All Gallerys of Same Priority',
+      'downloadAllGallerysOfSamePriorityHint':
+          'Download only 1 gallery simultaneously in 1 group with highest priority by default',
       'alwaysUseDefaultGroup': 'Sempre usar o grupo padrão',
-      'enableStoreMetadataForRestore': 'Ativar metadados da loja para restauração',
-      'enableStoreMetadataForRestoreHint': 'Se desabilitar isso, você não poderá restaurar as tarefas de download',
+      'enableStoreMetadataForRestore':
+          'Ativar metadados da loja para restauração',
+      'enableStoreMetadataForRestoreHint':
+          'Se desabilitar isso, você não poderá restaurar as tarefas de download',
       'archiveDownloadIsolateCount': 'Archive Download Thread Count',
-      'archiveDownloadIsolateCountHint': 'Sum of threads for all tasks needs to be less than 10, otherwise the download will fail',
+      'archiveDownloadIsolateCountHint':
+          'Sum of threads for all tasks needs to be less than 10, otherwise the download will fail',
       'manageArchiveDownloadConcurrency': 'Manage Archive Download Concurrency',
-      'manageArchiveDownloadConcurrencyHint': 'Archive will wait until there are enough threads to download',
-      'deleteArchiveFileAfterDownload': 'Delete Archive .zip File After Download',
+      'manageArchiveDownloadConcurrencyHint':
+          'Archive will wait until there are enough threads to download',
+      'deleteArchiveFileAfterDownload':
+          'Delete Archive .zip File After Download',
       'restoreDownloadTasks': 'Restaurar tarefas de download',
       'restoreDownloadTasksHint': 'Restaurar tarefas de download por metadados',
-      'restoreDownloadTasksSuccess': 'Tarefas de download restauradas com sucesso',
+      'restoreDownloadTasksSuccess':
+          'Tarefas de download restauradas com sucesso',
       'restoredCount': 'Contagem de tarefas restaurada',
       'restoredGalleryCount': 'Contagem de galerias restaurada',
       'restoredArchiveCount': 'Contagem de arquivos restaurada',
       'restoreTasksAutomatically': 'Restore Tasks Automatically',
-      'restoreTasksAutomaticallyHint': 'Restore tasks automatically when app launched',
-      'brokenDownloadPathHint': 'Parece que seu caminho de download está quebrado, a função de download pode ser ineficaz',
-      'brokenExtraScanPathHint': 'Seems your default local gallery path is broken, local gallery may be not recognized',
+      'restoreTasksAutomaticallyHint':
+          'Restore tasks automatically when app launched',
+      'brokenDownloadPathHint':
+          'Parece que seu caminho de download está quebrado, a função de download pode ser ineficaz',
+      'brokenExtraScanPathHint':
+          'Seems your default local gallery path is broken, local gallery may be not recognized',
       'useJH2UpdateGallery': 'Use JH server to accelerate gallery updates',
 
       /// archive bot settings
@@ -767,7 +858,8 @@ class pt_BR {
       'checkInFailed': 'Check-in failed',
       'checkInSuccess': 'Check-in success',
       'checkInSuccessHint': 'Got GP: %s, current total GP: %s.',
-      'pauseDownloadByInvalidArchiveBotKey': 'Archive bot settings is invalid, download paused',
+      'pauseDownloadByInvalidArchiveBotKey':
+          'Archive bot settings is invalid, download paused',
       'chooseArchiveParseSource': 'Change Parse Source',
       'official': 'Official',
       'archiveBot': 'Archive Bot',
@@ -796,7 +888,8 @@ class pt_BR {
       'upload2cloud': 'Upload to Cloud',
       'upload2cloudHint': 'Upload your current local configuration',
       'tap2upload': 'Tap to upload',
-      'copyIdentificationCodeSuccess': 'Upload successfully. Identification code has been copied',
+      'copyIdentificationCodeSuccess':
+          'Upload successfully. Identification code has been copied',
       'copyShareCode': 'Copy Share Code',
       'import': 'Import',
       'save2Local': 'Save to Local',
@@ -812,9 +905,11 @@ class pt_BR {
       'inputNumberHint': 'Please input a correct number',
       'inputRegexHint': 'Please input a correct regex',
       'useBuiltInBlockedUsers': 'Enable Built-in User Blocklist',
-      'useBuiltInBlockedUsersHint': 'Filter out gallery comments from users on the blocklist',
+      'useBuiltInBlockedUsersHint':
+          'Filter out gallery comments from users on the blocklist',
       'blockingRules': 'Block Rules',
-      'blockingRulesHint': 'Additional blocking rules for gallerys and comments',
+      'blockingRulesHint':
+          'Additional blocking rules for gallerys and comments',
       'blockingTarget': 'Blocking Target',
       'blockingAttribute': 'Blocking Attribute',
       'blockingPattern': 'Blocking Pattern',
@@ -828,7 +923,8 @@ class pt_BR {
       'content': 'Content',
       'incompleteInformation': 'Incomplete information',
       'noBlockingRuleHint': 'Add at least 1 rule',
-      'notSameBlockingRuleTargetHint': 'All sub-rules should have the same blocking target',
+      'notSameBlockingRuleTargetHint':
+          'All sub-rules should have the same blocking target',
       'blockingRuleHelp': '''
 Blocking Target: Filter galleries on the list page or filter comments on the details page. All sub-rules under the same rule must have the same blocking target.
 Blocking Attribute: Specify the attribute of the target based on which the rule is written to block.

--- a/lib/src/l18n/ru_RU.dart
+++ b/lib/src/l18n/ru_RU.dart
@@ -35,7 +35,8 @@ class ru_RU {
       'archiveError': 'Ошибка загрузки архива',
       'edit': 'Редактировать',
       'confirmDestructiveActions': 'Подтверждение необратимых действий',
-      'confirmDestructiveActionsHint': 'При включении перед необратимыми действиями, такими как удаление задач или повторная загрузка на странице загрузок, будет показываться диалог подтверждения',
+      'confirmDestructiveActionsHint':
+          'При включении перед необратимыми действиями, такими как удаление задач или повторная загрузка на странице загрузок, будет показываться диалог подтверждения',
 
       'home': "Главная",
       'gallery': "Галерея",
@@ -77,7 +78,8 @@ class ru_RU {
       'userName': 'Имя пользователя',
       'EHUser': 'Пользователь EH',
       'password': 'Пароль',
-      'needCaptcha': 'Требуется капча, пожалуйста, войдите снова через cookie или веб.',
+      'needCaptcha':
+          'Требуется капча, пожалуйста, войдите снова через cookie или веб.',
       'userNameOrPasswordMismatch': 'Неверное имя пользователя или пароль',
       'copyCookies': 'Скопировать Cookies',
       'tap2Copy': 'Нажмите, чтобы скопировать',
@@ -90,9 +92,11 @@ class ru_RU {
       'refreshIgneousFailed': 'Не удалось обновить Igneous',
 
       /// request
-      'sadPanda': 'Sad Panda (нет данных). См.: https://github.com/jiangtian616/JHenTai/wiki/Common-Questions',
+      'sadPanda':
+          'Sad Panda (нет данных). См.: https://github.com/jiangtian616/JHenTai/wiki/Common-Questions',
       // Оставляем Sad Panda
-      'sadPandaReferLink': 'https://github.com/jiangtian616/JHenTai/wiki/Common-Questions',
+      'sadPandaReferLink':
+          'https://github.com/jiangtian616/JHenTai/wiki/Common-Questions',
       // URL не переводим
 
       /// gallery card
@@ -132,18 +136,22 @@ class ru_RU {
       'noComments': 'Нет комментариев',
       'lastEditedOn': 'Последнее редактирование:',
       'getGalleryDetailFailed': 'Не удалось получить детали галереи',
-      'cloudflare403': 'You have been restricted by Cloudflare from making network requests. Please try switching networks or using another login method.',
+      'cloudflare403':
+          'You have been restricted by Cloudflare from making network requests. Please try switching networks or using another login method.',
       'invisible2User': 'Эта галерея невидима для Вас',
       'invisibleHints': 'Эта галерея удалена или недоступна.',
-      'copyRightHints': 'Эта галерея недоступна из-за претензии по авторским правам от: ',
+      'copyRightHints':
+          'Эта галерея недоступна из-за претензии по авторским правам от: ',
       'refreshGalleryDetailsFailed': 'Не удалось обновить детали галереи',
       'failToGetThumbnails': "Не удалось получить миниатюры",
       'favoriteGallerySuccess': "Галерея успешно добавлена в избранное",
       'favoriteGalleryFailed': "Не удалось добавить галерею в избранное",
       'removeFavoriteSuccess': "Успешно удалено из избранного",
       'removeFavoriteFailed': "Не удалось удалить из избранного",
-      'getGalleryFavoriteInfoFailed': 'Не удалось получить информацию об избранном для галереи',
-      'favoriteNoteSlotFullHint': 'Слоты заметок избранного заполнены, пожалуйста, сначала удалите некоторые заметки',
+      'getGalleryFavoriteInfoFailed':
+          'Не удалось получить информацию об избранном для галереи',
+      'favoriteNoteSlotFullHint':
+          'Слоты заметок избранного заполнены, пожалуйста, сначала удалите некоторые заметки',
       'ratingSuccess': 'Рейтинг успешно выставлен',
       'ratingFailed': 'Не удалось выставить рейтинг',
       'voteTagFailed': 'Не удалось проголосовать за тег',
@@ -151,12 +159,15 @@ class ru_RU {
       'resumeDownload': 'Возобновить загрузку',
       'pauseDownload': 'Приостановить загрузку',
       'addNewTagSetSuccess': 'Новый набор тегов успешно добавлен',
-      'addNewWatchedTagSetSuccess': 'Новый набор отслеживаемых тегов успешно добавлен',
+      'addNewWatchedTagSetSuccess':
+          'Новый набор отслеживаемых тегов успешно добавлен',
       'addNewHiddenTagSetSuccess': 'Новый набор скрытых тегов успешно добавлен',
-      'addNewTagSetSuccessHint': 'Вы можете проверить свои теги в Настройки -> EH -> Мои теги',
+      'addNewTagSetSuccessHint':
+          'Вы можете проверить свои теги в Настройки -> EH -> Мои теги',
       'addNewTagSetFailed': 'Не удалось добавить новый набор тегов',
       'VisitorStatistics': 'Статистика посетителей',
-      'invisible2UserWithoutDonation': 'Статистика этой галереи невидима для пользователей без доната',
+      'invisible2UserWithoutDonation':
+          'Статистика этой галереи невидима для пользователей без доната',
       'getGalleryStatisticsFailed': 'Не удалось получить статистику галереи',
       'totalVisits': 'Всего посещений',
       'visits': 'Посещений',
@@ -166,24 +177,30 @@ class ru_RU {
       'score': 'Оценка',
       'NotOnTheList': 'Нет в списке',
       'getGalleryArchiveFailed': 'Не удалось получить архив галереи',
-      'parseGalleryArchiveFailed': 'Ошибка парсинга, убедитесь, что ваши [Настройки архиватора] на e-hentai установлены как [Ручной выбор, Ручной запуск (По умолчанию)]',
+      'parseGalleryArchiveFailed':
+          'Ошибка парсинга, убедитесь, что ваши [Настройки архиватора] на e-hentai установлены как [Ручной выбор, Ручной запуск (По умолчанию)]',
       'original': 'Оригинал',
       'resample': 'Уменьшенная',
       'beginToDownloadArchive': 'Начать загрузку архива',
-      'beginToDownloadArchiveHint': 'Вы можете проверить прогресс в Загрузки -> Архив',
+      'beginToDownloadArchiveHint':
+          'Вы можете проверить прогресс в Загрузки -> Архив',
       'updateGalleryError': 'Ошибка обновления галереи',
       'thisGalleryHasANewVersion': 'У этой галереи есть новая версия',
       'hasUpdated': 'Обновлено',
       'unpackingArchiveError': 'Ошибка распаковки архива',
       'failedToDealWith': 'Не удалось обработать',
       'hasDownloaded': 'Уже загружено',
-      '410Hints': 'Вы скачали слишком много байт из этого архива, и требуется повторная разблокировка для возобновления.',
-      '429Hints': 'Слишком много запросов на загрузку! Вам лучше уменьшить количество одновременных загрузок архивов.',
-      'getUnpackedImagesFailedMsg': 'JHenTai не может загрузить изображения этого архива, пожалуйста, проверьте локальный файл.',
+      '410Hints':
+          'Вы скачали слишком много байт из этого архива, и требуется повторная разблокировка для возобновления.',
+      '429Hints':
+          'Слишком много запросов на загрузку! Вам лучше уменьшить количество одновременных загрузок архивов.',
+      'getUnpackedImagesFailedMsg':
+          'JHenTai не может загрузить изображения этого архива, пожалуйста, проверьте локальный файл.',
       // Оставляем JHenTai
       'getGalleryTorrentsFailed': 'Не удалось получить торренты',
       'chooseArchive': 'Выбрать архив',
-      'tagSetExceedLimit': 'Нельзя добавить больше тегов, так как вы достигли лимита',
+      'tagSetExceedLimit':
+          'Нельзя добавить больше тегов, так как вы достигли лимита',
       'useTranslation': 'Использовать перевод',
       'addTagSuccess': 'Тег успешно добавлен',
       'addTagFailed': 'Не удалось добавить тег',
@@ -207,7 +224,8 @@ class ru_RU {
       'commentTooShort': 'Комментарий слишком короткий',
       'sendCommentFailed': 'Не удалось отправить комментарий',
       'voteCommentFailed': 'Не удалось проголосовать за комментарий',
-      'voteCommentFailedHint': 'Попробуйте сначала потянуть вниз для обновления страницы деталей',
+      'voteCommentFailedHint':
+          'Попробуйте сначала потянуть вниз для обновления страницы деталей',
       'unknownUser': 'Неизвестный пользователь',
       'atLeast3Characters': 'Минимум 3 символа',
       'noJHenTaiHints': 'Пожалуйста, не упоминайте JHenTai, спасибо',
@@ -225,7 +243,8 @@ class ru_RU {
       'paused': 'На паузе',
       'exceedImageLimits': "Превышен лимит изображений",
       'ehServerError': 'Произошла ошибка на сервере EH, попробуйте позже',
-      'unsupportedImagePageStyle': "JHenTai не поддерживает Multi-Page Viewer(MPV), пожалуйста, измените стиль на стандартный на e-hentai.org",
+      'unsupportedImagePageStyle':
+          "JHenTai не поддерживает Multi-Page Viewer(MPV), пожалуйста, измените стиль на стандартный на e-hentai.org",
       // Оставляем JHenTai, MPV, e-hentai.org
       'toNext': 'К следующей',
       'toPrev': 'К предыдущей',
@@ -263,9 +282,11 @@ class ru_RU {
       /// eh setting page
       'site': 'Сайт',
       'redirect2Eh': 'Перенаправлять на EH, если доступно',
-      'redirect2EhHint': 'Сначала пытаться загрузить страницу с деталями галереи с сайта EH для лучшей производительности сети',
+      'redirect2EhHint':
+          'Сначала пытаться загрузить страницу с деталями галереи с сайта EH для лучшей производительности сети',
       'redirectAllGallery': 'Перенаправлять все галереи на EH',
-      'imDonorHint': 'Если вы донор, вы можете включить это, чтобы получить доступ к галереям на сайте EX',
+      'imDonorHint':
+          'Если вы донор, вы можете включить это, чтобы получить доступ к галереям на сайте EX',
       'profileSetting': 'Настройка профиля',
       'chooseProfileHint': 'Выберите профиль для использования в JHenTai',
       'siteSetting': 'Настройки сайта',
@@ -314,20 +335,25 @@ class ru_RU {
       'tabletLayoutName': 'Планшетный (старый)',
       'tabletLayoutDesc': 'Поддержка прекращена',
       'desktopLayoutName': 'Десктопный',
-      'desktopLayoutDesc': 'Две колонки с левой панелью вкладок, поддержка клавиатуры',
+      'desktopLayoutDesc':
+          'Две колонки с левой панелью вкладок, поддержка клавиатуры',
 
       /// style setting page
       'enableTagZHTranslation': 'Переводить названия тегов на китайский',
       'version': 'Версия',
       'downloadTagTranslationHint': 'Загрузка данных..., загружено: ',
-      'zhTagSearchOrderOptimization': 'Правило сортировки автодополнения китайских тегов',
-      'zhTagSearchOrderOptimizationHint': 'Интеллектуальная сортировка по умолчанию, по частоте, если включено',
+      'zhTagSearchOrderOptimization':
+          'Правило сортировки автодополнения китайских тегов',
+      'zhTagSearchOrderOptimizationHint':
+          'Интеллектуальная сортировка по умолчанию, по частоте, если включено',
       'themeMode': 'Тема оформления',
       'dark': 'Темная',
       'light': 'Светлая',
       'followSystem': 'Как в системе',
       'themeColor': 'Цвет темы',
       'themeColorFixedOnApple': 'Фиксированный акцентный цвет на macOS / iOS',
+      'appleVisualStyle': 'Визуальный стиль Apple',
+      'appleVisualStyleHint': 'Включить обновленный интерфейс на macOS и iOS',
       'listStyle': 'Стиль списка галерей (Глобально)',
       'flat': 'Плоский',
       'flatWithoutTags': 'Плоский (Без тегов)',
@@ -338,8 +364,10 @@ class ru_RU {
       'waterfallFlowBig': 'Плитка (Большая)',
       'crossAxisCountInWaterFallFlow': 'Количество колонок в плитке',
       'pageListStyle': 'Стиль списка галерей (Страница)',
-      'crossAxisCountInGridDownloadPageForGroup': 'Кол-во колонок на стр. загрузок (Группа)',
-      'crossAxisCountInGridDownloadPageForGallery': 'Кол-во колонок на стр. загрузок (Галерея)',
+      'crossAxisCountInGridDownloadPageForGroup':
+          'Кол-во колонок на стр. загрузок (Группа)',
+      'crossAxisCountInGridDownloadPageForGallery':
+          'Кол-во колонок на стр. загрузок (Галерея)',
       'crossAxisCountInDetailPage': 'Кол-во колонок миниатюр на стр. деталей',
       'global': 'Глобально',
       'auto': 'Авто',
@@ -354,10 +382,12 @@ class ru_RU {
       'whenScrollUp': 'При прокрутке вверх',
       'whenScrollDown': 'При прокрутке вниз',
       'preloadGalleryCover': 'Предзагружать обложки галерей',
-      'preloadGalleryCoverHint': 'Предзагружать обложки галерей, еще не отображенных на странице',
+      'preloadGalleryCoverHint':
+          'Предзагружать обложки галерей, еще не отображенных на странице',
       'enableSwipeBackGesture': 'Включить жест "Назад" свайпом',
       'enableLeftMenuDrawerGesture': 'Включить жест открытия левого меню',
-      'enableQuickSearchDrawerGesture': 'Включить жест открытия быстрого поиска',
+      'enableQuickSearchDrawerGesture':
+          'Включить жест открытия быстрого поиска',
       'drawerGestureEdgeWidth': 'Ширина края для жеста меню',
       'alwaysShowScroll2TopButton': 'Всегда показывать кнопку "Наверх"',
       'enableDefaultFavorite': 'Включить избранное по умолчанию',
@@ -370,18 +400,24 @@ class ru_RU {
       'disableDefaultFavoriteHint': 'Выбирать вручную',
       'searchBehaviour': 'Поведение поиска',
       'inheritAll': 'Наследовать все',
-      'inheritAllHint': 'Использовать последние параметры для следующего поиска',
+      'inheritAllHint':
+          'Использовать последние параметры для следующего поиска',
       'inheritPartially': 'Наследовать частично',
-      'inheritPartiallyHint': 'Использовать последние параметры (кроме языка и категории)',
+      'inheritPartiallyHint':
+          'Использовать последние параметры (кроме языка и категории)',
       'none': 'Нет',
       'noneHint': 'Использовать параметры по умолчанию для следующего поиска',
       'showAllGalleryTitles': 'Показывать все названия галерей',
-      'showAllGalleryTitlesHint': 'Показывать оригинальное и японское названия, если доступны',
-      'showGalleryTagVoteStatus': 'Показывать статус голосования за теги галереи',
-      'showGalleryTagVoteStatusHint': 'Включая уверенность, скептицизм и неверность',
+      'showAllGalleryTitlesHint':
+          'Показывать оригинальное и японское названия, если доступны',
+      'showGalleryTagVoteStatus':
+          'Показывать статус голосования за теги галереи',
+      'showGalleryTagVoteStatusHint':
+          'Включая уверенность, скептицизм и неверность',
       'showComments': 'Показывать комментарии',
       'showAllComments': 'Показывать все комментарии',
-      'showAllCommentsHint': 'По умолчанию показываются только 45 лучших и 5 последних',
+      'showAllCommentsHint':
+          'По умолчанию показываются только 45 лучших и 5 последних',
       'addTag': 'Добавить тег',
       'addTagHint': 'Введите новые теги через запятую',
 
@@ -392,8 +428,10 @@ class ru_RU {
       'custom': 'Пользовательский',
 
       /// performance setting page
-      'maxGalleryNum4Animation': 'Макс. кол-во галерей для анимации списка на стр. загрузок',
-      'maxGalleryNum4AnimationHint': 'Отключить анимацию для групп с большим кол-вом галерей (для стиля списка)',
+      'maxGalleryNum4Animation':
+          'Макс. кол-во галерей для анимации списка на стр. загрузок',
+      'maxGalleryNum4AnimationHint':
+          'Отключить анимацию для групп с большим кол-вом галерей (для стиля списка)',
 
       /// mouse wheel setting page
       'wheelScrollSpeed': 'Скорость прокрутки колесом',
@@ -405,7 +443,8 @@ class ru_RU {
       'hostMapping': 'Сопоставление хостов',
       'hostMappingHint': 'Используется для domain fronting',
       'proxyAddress': 'Адрес прокси',
-      'proxyAddressHint': 'Если вы используете прокси-сервер, настройте его правильно',
+      'proxyAddressHint':
+          'Если вы используете прокси-сервер, настройте его правильно',
       'saveSuccess': 'Успешно сохранено',
       'saveFailed': 'Не удалось сохранить',
       'updateSuccess': 'Успешно обновлено',
@@ -414,7 +453,8 @@ class ru_RU {
       'pageCacheMaxAge': 'Время жизни кэша страниц',
       'pageCacheMaxAgeHint': 'Вы можете обновить кэш, обновив страницу',
       'cacheImageExpireDuration': 'Время жизни кэша изображений',
-      'cacheImageExpireDurationHint': 'Автоматически удалять кэш изображений после запуска приложения',
+      'cacheImageExpireDurationHint':
+          'Автоматически удалять кэш изображений после запуска приложения',
       'oneMinute': '1 минута',
       'tenMinute': '10 минут',
       'oneHour': '1 час',
@@ -433,19 +473,23 @@ class ru_RU {
       'superResolution': 'Супер-разрешение изображений',
       'stopSuperResolution': 'Остановить супер-разрешение',
       'deleteSuperResolvedImage': 'Удалить обработанное изображение',
-      'superResolveOriginalImageHint': 'Обработка оригинального изображения требует больше времени, места и ресурсов. Продолжить?',
+      'superResolveOriginalImageHint':
+          'Обработка оригинального изображения требует больше времени, места и ресурсов. Продолжить?',
       'verityAppLinks4Android12': 'Проверка ссылок приложений (Android 12+)',
-      'verityAppLinks4Android12Hint': 'Для Android 12+ нужно вручную добавить ссылки в проверенные, чтобы открывать JHenTai из сторонних приложений',
+      'verityAppLinks4Android12Hint':
+          'Для Android 12+ нужно вручную добавить ссылки в проверенные, чтобы открывать JHenTai из сторонних приложений',
       // Оставляем JHenTai
       'noImageMode': 'Режим без изображений',
       'exportData': 'Экспорт данных',
       'exportDataHint': 'Экспорт настроек, правил блокировки и истории',
       'selectExportItems': 'Выбрать элементы для экспорта',
       'importData': 'Импорт данных',
-      'importDataHint': 'Приложение автоматически закроется после импорта для применения конфигурации',
+      'importDataHint':
+          'Приложение автоматически закроется после импорта для применения конфигурации',
 
       /// host mapping page
-      'hostDataSource': 'По умолчанию менять не нужно.\nИсточник данных: https://dns.google/',
+      'hostDataSource':
+          'По умолчанию менять не нужно.\nИсточник данных: https://dns.google/',
       // URL не переводим
 
       /// proxy page
@@ -465,12 +509,14 @@ class ru_RU {
       'enableAuthOnResumeHints': 'Задержка 3 секунды',
       'enableBlurBackgroundApp': 'Размывать фон при сворачивании',
       'hideImagesInAlbum': 'Скрывать изображения в альбоме',
-      'hideImagesInAlbumHints': 'Если изменен путь загрузки по умолчанию, нужно создать .nomedia вручную',
+      'hideImagesInAlbumHints':
+          'Если изменен путь загрузки по умолчанию, нужно создать .nomedia вручную',
 
       /// read setting page
       'enableImmersiveMode': 'Включить иммерсивный режим',
       'keepScreenAwakeWhenReading': 'Не выключать экран при чтении',
-      'enableCustomReadBrightness': 'Включить пользовательскую яркость при чтении',
+      'enableCustomReadBrightness':
+          'Включить пользовательскую яркость при чтении',
       'spaceBetweenImages': 'Пространство между изображениями',
       'enableImmersiveHint': 'Скрыть системную панель',
       'enableImmersiveHint4Windows': 'Скрыть заголовок окна',
@@ -478,13 +524,16 @@ class ru_RU {
       'landscape': 'Альбомная',
       'portrait': 'Портретная',
       'readDirection': 'Направление чтения',
-      'enableOrientationSpecificReadDirection': 'Направление чтения по ориентации',
-      'enableOrientationSpecificReadDirectionHint': 'Установить разное направление чтения для портретной и альбомной ориентации',
+      'enableOrientationSpecificReadDirection':
+          'Направление чтения по ориентации',
+      'enableOrientationSpecificReadDirectionHint':
+          'Установить разное направление чтения для портретной и альбомной ориентации',
       'portraitReadDirection': 'Направление чтения (портрет)',
       'landscapeReadDirection': 'Направление чтения (альбом)',
       'autoSwitchedReadDirection': 'Авто-смена направления чтения',
       'notchOptimization': 'Оптимизация под вырез',
-      'notchOptimizationHint': 'Добавить отступ перед первым изображением, чтобы избежать выреза и строки состояния',
+      'notchOptimizationHint':
+          'Добавить отступ перед первым изображением, чтобы избежать выреза и строки состояния',
       'imageRegionWidthRatio': 'Соотношение ширины области изображения',
       'portraitImageRegionWidthRatio': 'Ширина изображения (портрет)',
       'landscapeImageRegionWidthRatio': 'Ширина изображения (ландшафт)',
@@ -507,8 +556,10 @@ class ru_RU {
       'right2leftDoubleColumn': 'Справа налево (Две колонки)',
       'left2rightList': 'Слева направо (Непрерывно)',
       'right2leftList': 'Справа налево (Непрерывно)',
-      'enablePageTurnByVolumeKeys': 'Использовать клавиши громкости для перелистывания',
-      'enablePageTurnByVolumeKeysHint': 'В iOS, если громкость равна 0 или 100%, при входе в режим чтения она будет автоматически изменена для поддержки перелистывания и восстановлена при выходе',
+      'enablePageTurnByVolumeKeys':
+          'Использовать клавиши громкости для перелистывания',
+      'enablePageTurnByVolumeKeysHint':
+          'В iOS, если громкость равна 0 или 100%, при входе в режим чтения она будет автоматически изменена для поддержки перелистывания и восстановлена при выходе',
       'enablePageTurnAnime': 'Включить анимацию перелистывания',
       'enableDoubleTapToScaleUp': 'Включить двойной тап для увеличения',
       'enableTapDragToScaleUp': 'Включить тап с перетаскиванием для увеличения',
@@ -527,12 +578,20 @@ class ru_RU {
       'preloadDistanceInLocalMode': 'Дистанция предзагрузки (Локально)',
       'ScreenHeight': 'Экран',
       'preloadPageCount': 'Кол-во предзагружаемых страниц (Онлайн)',
-      'preloadPageCountInLocalMode': 'Кол-во предзагружаемых страниц (Локально)',
+      'preloadPageCountInLocalMode':
+          'Кол-во предзагружаемых страниц (Локально)',
+      'failedImageRetryScope': "Область повторной загрузки изображений",
+      'failedImageRetryScopeHint':
+          "Область, применяемая при нажатии на неудачное онлайн-изображение для перезагрузки",
+      'retrySingleImage': "Только это изображение",
+      'retryCurrentPageAndAfter': "Текущее и последующие",
+      'retryAllFailedImages': "Все неудачные изображения",
       'continuousScroll': 'Непрерывная прокрутка',
       'continuousScrollHint': 'Склеивать несколько изображений',
       'doubleColumn': 'Две колонки',
       'displayFirstPageAlone': 'Отображать первую страницу отдельно',
-      'displayFirstPageAloneGlobally': 'Отображать первую страницу отдельно (Глобально)',
+      'displayFirstPageAloneGlobally':
+          'Отображать первую страницу отдельно (Глобально)',
       'portraitDisplayFirstPageAlone': 'Первая страница отдельно (портрет)',
       'landscapeDisplayFirstPageAlone': 'Первая страница отдельно (ландшафт)',
       'toggleFullScreen': 'Переключить полноэкранный режим',
@@ -545,13 +604,15 @@ class ru_RU {
       'resetSuccess': 'Сброшено до значений по умолчанию',
       'keyConflict': 'Конфликт клавиш',
       'fixedKeyHint': 'Фиксированная клавиша, не настраивается',
-      'pressAnyKeyOrMouseSideButton': 'Нажмите любую клавишу или боковую кнопку мыши...',
+      'pressAnyKeyOrMouseSideButton':
+          'Нажмите любую клавишу или боковую кнопку мыши...',
       'mouseButton4Name': 'Мышь вперёд',
       'mouseButton5Name': 'Мышь назад',
       'toLeft': 'Влево',
       'toRight': 'Вправо',
       'enableAutoScaleUp': 'Включить авто-масштабирование длинных изображений',
-      'enableAutoScaleUpHints': 'Сделать ширину изображения равной ширине экрана',
+      'enableAutoScaleUpHints':
+          'Сделать ширину изображения равной ширине экрана',
 
       /// preference setting page
       'showR18GImageDirectly': 'Показывать R18G изображения сразу',
@@ -559,7 +620,8 @@ class ru_RU {
       'defaultDownloadTab': 'Вкладка загрузок по умолчанию',
       'showUtcTime': 'Показывать UTC время для галерей',
       'showDawnInfo': 'Показывать событие "Новый рассвет"',
-      'showEncounterMonster': 'Показывать событие "Встреча с монстром" (HentaiVerse)',
+      'showEncounterMonster':
+          'Показывать событие "Встреча с монстром" (HentaiVerse)',
 
       /// log page
       'logList': 'Список логов',
@@ -592,10 +654,14 @@ class ru_RU {
       'completed': 'Завершено',
       'needReUnlock': 'Нужна повторная разблокировка',
       'reUnlock': 'Разблокировать заново',
-      'reUnlockHint': 'Внимание! Повторная разблокировка требует повторной покупки архива.',
-      'downloadHelpInfo': 'Если вы не можете скачать и видите ошибки типа "table doesn\'t exist" в логах, удалите и переустановите приложение.',
-      'localGalleryHelpInfo': 'Загрузка галерей, скачанных не через JHenTai. Добавьте путь в Настройки загрузки -> Доп. путь сканирования, затем обновите.',
-      'localGalleryHelpInfo4iOSAndMacOS': 'Загрузка галерей, скачанных не через JHenTai. Поместите галереи в путь загрузки по умолчанию, затем обновите.',
+      'reUnlockHint':
+          'Внимание! Повторная разблокировка требует повторной покупки архива.',
+      'downloadHelpInfo':
+          'Если вы не можете скачать и видите ошибки типа "table doesn\'t exist" в логах, удалите и переустановите приложение.',
+      'localGalleryHelpInfo':
+          'Загрузка галерей, скачанных не через JHenTai. Добавьте путь в Настройки загрузки -> Доп. путь сканирования, затем обновите.',
+      'localGalleryHelpInfo4iOSAndMacOS':
+          'Загрузка галерей, скачанных не через JHenTai. Поместите галереи в путь загрузки по умолчанию, затем обновите.',
       'deleteLocalGalleryHint': 'Удалить ваши локальные файлы',
       'priority': 'Приоритет',
       'highest': 'Высший',
@@ -622,14 +688,19 @@ class ru_RU {
       'multiReDownloadHint': 'Вы перекачаете все выбранные галереи.',
       'multiChangeGroupHint': 'Вы измените группу для всех выбранных галерей.',
       'multiDeleteHint': 'Вы удалите все выбранные галереи.',
-      'blankImageHint': 'Downloading the image returned an empty result, trying to re-parse.',
-      'peakHoursHint': 'Загрузка оригинальных файлов в часы пик требует GP, у вас недостаточно. Загрузка приостановлена.',
+      'blankImageHint':
+          'Downloading the image returned an empty result, trying to re-parse.',
+      'peakHoursHint':
+          'Загрузка оригинальных файлов в часы пик требует GP, у вас недостаточно. Загрузка приостановлена.',
       // GP - термин EH
-      'oldGalleryHint': 'Загрузка оригинальных файлов этой галереи требует GP, у вас недостаточно.',
+      'oldGalleryHint':
+          'Загрузка оригинальных файлов этой галереи требует GP, у вас недостаточно.',
       // GP - термин EH
-      'exceedLimitHint': 'Вы достигли лимита изображений и не имеете достаточно GP для покупки квоты.',
+      'exceedLimitHint':
+          'Вы достигли лимита изображений и не имеете достаточно GP для покупки квоты.',
       // GP - термин EH
-      'deleteUpdatingDependentHint': 'Обновление другой галереи зависит от текущей, лучше удалить после завершения обновления.',
+      'deleteUpdatingDependentHint':
+          'Обновление другой галереи зависит от текущей, лучше удалить после завершения обновления.',
       'migrateToDownload': 'Перенести в 「Загрузки」',
       'refresh': 'Обновить',
 
@@ -670,7 +741,8 @@ class ru_RU {
       'pageAtLeast': 'Страниц минимум',
       'pageAtMost': 'Страниц максимум',
       'pagesBetween': 'Страниц между',
-      'pageRangeSelectHint': 'мин <= 1000, макс >= 10\nмин/макс <= 0.8, макс-мин >= 20',
+      'pageRangeSelectHint':
+          'мин <= 1000, макс >= 10\nмин/макс <= 0.8, макс-мин >= 20',
       'to': 'до',
       'minimumRating': 'Минимальный рейтинг',
       'disableFilterForLanguage': 'Отключить фильтр по языку',
@@ -701,7 +773,8 @@ class ru_RU {
       'fileSearchFailed': 'Ошибка поиска по файлу',
       'tab': 'Вкладка',
       'openGallery': 'Открыть галерею',
-      'tapChip2Delete': 'Нажмите на чип для удаления\nДолгий тап на кнопку для удаления всего',
+      'tapChip2Delete':
+          'Нажмите на чип для удаления\nДолгий тап на кнопку для удаления всего',
       'accurateCountTemplate': '%s результатов',
       'hundredsOfCountTemplate': 'Сотни результатов',
       'thousandsOfCountTemplate': 'Тысячи результатов',
@@ -717,21 +790,26 @@ class ru_RU {
           'Долгий тап для изменения (не используйте SD-карту или системные пути). Скачанные галереи будут скопированы автоматически, старые файлы сохранены. При ошибках попробуйте сбросить.',
       'resetDownloadPath': 'Сбросить путь загрузки',
       'extraGalleryScanPath': 'Доп. путь сканирования галерей',
-      'extraGalleryScanPathHint': 'Для сканирования и загрузки локальных галерей',
+      'extraGalleryScanPathHint':
+          'Для сканирования и загрузки локальных галерей',
       'singleImageSavePath': 'Путь сохранения отдельных изображений',
       'downloadOriginalImage': 'Оригинальное изображение',
-      'downloadOriginalImageByDefault': 'Выбирать оригинальное изображение по умолчанию',
+      'downloadOriginalImageByDefault':
+          'Выбирать оригинальное изображение по умолчанию',
       'originalImage': 'Оригинал',
       'resampleImage': 'Уменьшенное',
       'defaultGalleryGroup': 'Группа галерей по умолчанию',
-      'prioritizeRecentGalleryGroups': 'Недавние группы галерей в начале списка',
+      'prioritizeRecentGalleryGroups':
+          'Недавние группы галерей в начале списка',
       'defaultArchiveGroup': 'Группа архивов по умолчанию',
       'never': 'Никогда',
       'manual': 'Вручную',
       'always': 'Всегда',
       'longPress2Reset': 'Долгий тап для сброса',
-      'needPermissionToChangeDownloadPath': 'Нужно разрешение для изменения пути загрузки',
-      'invalidPath': 'Недопустимый путь. Избегайте SD-карт, системных путей или корневого каталога.',
+      'needPermissionToChangeDownloadPath':
+          'Нужно разрешение для изменения пути загрузки',
+      'invalidPath':
+          'Недопустимый путь. Избегайте SD-карт, системных путей или корневого каталога.',
       'downloadTaskConcurrency': 'Параллельные загрузки',
       'needRestart': 'Требуется перезапуск',
       'speedLimit': 'Ограничение скорости',
@@ -739,16 +817,24 @@ class ru_RU {
       'per': 'за',
       'images': 'изображений',
       'downloadTimeout': 'Тайм-аут загрузки',
-      'downloadAllGallerysOfSamePriority': 'Загружать все галереи одного приоритета',
-      'downloadAllGallerysOfSamePriorityHint': 'По умолчанию загружать только 1 галерею одновременно в 1 группе с высшим приоритетом',
+      'downloadAllGallerysOfSamePriority':
+          'Загружать все галереи одного приоритета',
+      'downloadAllGallerysOfSamePriorityHint':
+          'По умолчанию загружать только 1 галерею одновременно в 1 группе с высшим приоритетом',
       'alwaysUseDefaultGroup': 'Всегда использовать группу по умолчанию',
-      'enableStoreMetadataForRestore': 'Включить сохранение метаданных для восстановления',
-      'enableStoreMetadataForRestoreHint': 'Если отключено, вы не сможете восстановить задачи загрузки',
+      'enableStoreMetadataForRestore':
+          'Включить сохранение метаданных для восстановления',
+      'enableStoreMetadataForRestoreHint':
+          'Если отключено, вы не сможете восстановить задачи загрузки',
       'archiveDownloadIsolateCount': 'Кол-во потоков загрузки архивов',
-      'archiveDownloadIsolateCountHint': 'Сумма потоков для всех задач должна быть < 10, иначе загрузка не удастся',
-      'manageArchiveDownloadConcurrency': 'Управлять параллелизмом загрузки архивов',
-      'manageArchiveDownloadConcurrencyHint': 'Архив будет ждать, пока не освободятся потоки для загрузки',
-      'deleteArchiveFileAfterDownload': 'Удалять ZIP-файл архива после загрузки',
+      'archiveDownloadIsolateCountHint':
+          'Сумма потоков для всех задач должна быть < 10, иначе загрузка не удастся',
+      'manageArchiveDownloadConcurrency':
+          'Управлять параллелизмом загрузки архивов',
+      'manageArchiveDownloadConcurrencyHint':
+          'Архив будет ждать, пока не освободятся потоки для загрузки',
+      'deleteArchiveFileAfterDownload':
+          'Удалять ZIP-файл архива после загрузки',
       'restoreDownloadTasks': 'Восстановить задачи загрузки',
       'restoreDownloadTasksHint': 'Восстановить задачи загрузки по метаданным',
       'restoreDownloadTasksSuccess': 'Задачи загрузки успешно восстановлены',
@@ -756,9 +842,12 @@ class ru_RU {
       'restoredGalleryCount': 'Восстановлено галерей',
       'restoredArchiveCount': 'Восстановлено архивов',
       'restoreTasksAutomatically': 'Восстанавливать задачи автоматически',
-      'restoreTasksAutomaticallyHint': 'Восстанавливать задачи автоматически при запуске приложения',
-      'brokenDownloadPathHint': 'Похоже, ваш путь загрузки поврежден, функция загрузки может не работать',
-      'brokenExtraScanPathHint': 'Похоже, ваш путь к локальным галереям поврежден, локальные галереи могут не распознаваться',
+      'restoreTasksAutomaticallyHint':
+          'Восстанавливать задачи автоматически при запуске приложения',
+      'brokenDownloadPathHint':
+          'Похоже, ваш путь загрузки поврежден, функция загрузки может не работать',
+      'brokenExtraScanPathHint':
+          'Похоже, ваш путь к локальным галереям поврежден, локальные галереи могут не распознаваться',
       'useJH2UpdateGallery': 'Use JH server to accelerate gallery updates',
 
       /// archive bot settings
@@ -775,7 +864,8 @@ class ru_RU {
       'checkInFailed': 'Check-in failed',
       'checkInSuccess': 'Check-in success',
       'checkInSuccessHint': 'Got GP: %s, current total GP: %s.',
-      'pauseDownloadByInvalidArchiveBotKey': 'Archive bot settings is invalid, download paused',
+      'pauseDownloadByInvalidArchiveBotKey':
+          'Archive bot settings is invalid, download paused',
       'chooseArchiveParseSource': 'Change Parse Source',
       'official': 'Official',
       'archiveBot': 'Archive Bot',
@@ -804,7 +894,8 @@ class ru_RU {
       'upload2cloud': 'Загрузить в облако',
       'upload2cloudHint': 'Загрузить вашу текущую локальную конфигурацию',
       'tap2upload': 'Нажмите для загрузки',
-      'copyIdentificationCodeSuccess': 'Загружено успешно. Идентификационный код скопирован',
+      'copyIdentificationCodeSuccess':
+          'Загружено успешно. Идентификационный код скопирован',
       'copyShareCode': 'Скопировать код для обмена',
       'import': 'Импорт',
       'save2Local': 'Сохранить локально',
@@ -819,10 +910,13 @@ class ru_RU {
       'removeBlockRuleFailed': 'Не удалось удалить правило блокировки',
       'inputNumberHint': 'Пожалуйста, введите корректное число',
       'inputRegexHint': 'Пожалуйста, введите корректное регулярное выражение',
-      'useBuiltInBlockedUsers': 'Включить встроенный список заблокированных пользователей',
-      'useBuiltInBlockedUsersHint': 'Фильтровать комментарии от пользователей из списка блокировки',
+      'useBuiltInBlockedUsers':
+          'Включить встроенный список заблокированных пользователей',
+      'useBuiltInBlockedUsersHint':
+          'Фильтровать комментарии от пользователей из списка блокировки',
       'blockingRules': 'Правила блокировки',
-      'blockingRulesHint': 'Дополнительные правила блокировки для галерей и комментариев',
+      'blockingRulesHint':
+          'Дополнительные правила блокировки для галерей и комментариев',
       'blockingTarget': 'Цель блокировки',
       'blockingAttribute': 'Атрибут блокировки',
       'blockingPattern': 'Шаблон блокировки',
@@ -836,7 +930,8 @@ class ru_RU {
       'content': 'Содержимое',
       'incompleteInformation': 'Неполная информация',
       'noBlockingRuleHint': 'Добавьте хотя бы 1 правило',
-      'notSameBlockingRuleTargetHint': 'Все подправила должны иметь одну и ту же цель блокировки',
+      'notSameBlockingRuleTargetHint':
+          'Все подправила должны иметь одну и ту же цель блокировки',
       'blockingRuleHelp': '''
 Цель блокировки: Фильтровать галереи в списке или комментарии на странице деталей. Все подправила в одном правиле должны иметь одну цель.
 Атрибут блокировки: Указывает атрибут цели, по которому пишется правило.

--- a/lib/src/l18n/ru_RU.dart
+++ b/lib/src/l18n/ru_RU.dart
@@ -327,6 +327,7 @@ class ru_RU {
       'light': 'Светлая',
       'followSystem': 'Как в системе',
       'themeColor': 'Цвет темы',
+      'themeColorFixedOnApple': 'Фиксированный акцентный цвет на macOS / iOS',
       'listStyle': 'Стиль списка галерей (Глобально)',
       'flat': 'Плоский',
       'flatWithoutTags': 'Плоский (Без тегов)',

--- a/lib/src/l18n/zh_CN.dart
+++ b/lib/src/l18n/zh_CN.dart
@@ -322,6 +322,7 @@ class zh_CN {
       'light': '明亮',
       'followSystem': '跟随系统',
       'themeColor': '主题颜色',
+      'themeColorFixedOnApple': 'macOS / iOS 使用固定强调色',
       'listStyle': '画廊列表样式(全局)',
       'flat': '平坦',
       'flatWithoutTags': '平坦 - 无标签',

--- a/lib/src/l18n/zh_CN.dart
+++ b/lib/src/l18n/zh_CN.dart
@@ -90,8 +90,10 @@ class zh_CN {
       'refreshIgneousFailed': '刷新Igneous失败',
 
       /// request
-      'sadPanda': 'Sad Panda(无响应数据). 解决参考Github Wiki: https://github.com/jiangtian616/JHenTai/wiki/%E5%B8%B8%E8%A7%81%E9%97%AE%E9%A2%98',
-      'sadPandaReferLink': 'https://github.com/jiangtian616/JHenTai/wiki/%E5%B8%B8%E8%A7%81%E9%97%AE%E9%A2%98',
+      'sadPanda':
+          'Sad Panda(无响应数据). 解决参考Github Wiki: https://github.com/jiangtian616/JHenTai/wiki/%E5%B8%B8%E8%A7%81%E9%97%AE%E9%A2%98',
+      'sadPandaReferLink':
+          'https://github.com/jiangtian616/JHenTai/wiki/%E5%B8%B8%E8%A7%81%E9%97%AE%E9%A2%98',
 
       /// gallery card
       'filtered': '已过滤',
@@ -164,7 +166,8 @@ class zh_CN {
       'score': '分数',
       'NotOnTheList': '未上榜',
       'getGalleryArchiveFailed': '获取归档数据失败',
-      'parseGalleryArchiveFailed': '解析错误，确保你e站的[Archiver Settings]设置的是[Manual Select, Manual Start (Default)]',
+      'parseGalleryArchiveFailed':
+          '解析错误，确保你e站的[Archiver Settings]设置的是[Manual Select, Manual Start (Default)]',
       'original': '原图',
       'resample': '压缩',
       'beginToDownloadArchive': '开始下载归档',
@@ -221,7 +224,8 @@ class zh_CN {
       'paused': '已暂停',
       'exceedImageLimits': "超出图片配额限制",
       'ehServerError': 'E站服务器发生错误，请稍后重试',
-      'unsupportedImagePageStyle': "JHenTai当前不支持Multi-Page Viewer(MPV)多页查看，请在e-hentai.org更换为默认风格",
+      'unsupportedImagePageStyle':
+          "JHenTai当前不支持Multi-Page Viewer(MPV)多页查看，请在e-hentai.org更换为默认风格",
       'toNext': '下一页',
       'toPrev': '上一页',
       'back': '返回',
@@ -323,6 +327,8 @@ class zh_CN {
       'followSystem': '跟随系统',
       'themeColor': '主题颜色',
       'themeColorFixedOnApple': 'macOS / iOS 使用固定强调色',
+      'appleVisualStyle': 'Apple 视觉样式',
+      'appleVisualStyleHint': '启用 macOS / iOS 的重设计界面',
       'listStyle': '画廊列表样式(全局)',
       'flat': '平坦',
       'flatWithoutTags': '平坦 - 无标签',
@@ -431,7 +437,8 @@ class zh_CN {
       'deleteSuperResolvedImage': '删除图片超分辨率后的图片',
       'superResolveOriginalImageHint': '处理原图会耗费更多的时间、空间和性能，确定继续？',
       'verityAppLinks4Android12': '验证应用链接（安卓12+）',
-      'verityAppLinks4Android12Hint': '对于Android 12+，您需要手动添加链接到已验证链接才能在其他应用中唤起JHenTai',
+      'verityAppLinks4Android12Hint':
+          '对于Android 12+，您需要手动添加链接到已验证链接才能在其他应用中唤起JHenTai',
       'noImageMode': '无图模式',
       'exportData': '导出数据',
       'exportDataHint': '导出配置、屏蔽规则与历史记录',
@@ -502,7 +509,8 @@ class zh_CN {
       'left2rightList': '从左至右(连续)',
       'right2leftList': '从右至左(连续)',
       'enablePageTurnByVolumeKeys': '使用音量键翻页',
-      'enablePageTurnByVolumeKeysHint': 'iOS 上，若音量为 0 或 100%，进入阅读页时音量将被自动调整以支持翻页，退出后恢复',
+      'enablePageTurnByVolumeKeysHint':
+          'iOS 上，若音量为 0 或 100%，进入阅读页时音量将被自动调整以支持翻页，退出后恢复',
       'enablePageTurnAnime': '开启翻页动画',
       'enableDoubleTapToScaleUp': '允许双击放大图片',
       'enableTapDragToScaleUp': '允许单击后拖拽放大图片',
@@ -522,6 +530,11 @@ class zh_CN {
       'ScreenHeight': '屏幕',
       'preloadPageCount': '预载图片数量(在线模式)',
       'preloadPageCountInLocalMode': '预载图片数量(本地模式)',
+      'failedImageRetryScope': "失败图片重试范围",
+      'failedImageRetryScopeHint': "点击加载失败的在线图片进行重试时，一次重试的范围",
+      'retrySingleImage': "仅当前图片",
+      'retryCurrentPageAndAfter': "当前图片及之后",
+      'retryAllFailedImages': "全部失败图片",
       'continuousScroll': '连续滚动',
       'continuousScrollHint': '拼接多个图片',
       'doubleColumn': '双列模式',
@@ -588,8 +601,10 @@ class zh_CN {
       'reUnlock': '重新解锁',
       'reUnlockHint': '注意！重新解锁需要重新购买此归档！',
       'downloadHelpInfo': '如果发现无法下载，在日志中发现了数据库表不存在等问题，卸载当前app重装即可。',
-      'localGalleryHelpInfo': '加载那些不是由JHenTai下载的画廊(当做本地阅览器)。在下载设置-额外的画廊扫描路径中配置，之后刷新即可',
-      'localGalleryHelpInfo4iOSAndMacOS': '加载那些不是由JHenTai下载的画廊(当做本地阅览器)。将你的画廊放在默认下载路径下，之后刷新即可',
+      'localGalleryHelpInfo':
+          '加载那些不是由JHenTai下载的画廊(当做本地阅览器)。在下载设置-额外的画廊扫描路径中配置，之后刷新即可',
+      'localGalleryHelpInfo4iOSAndMacOS':
+          '加载那些不是由JHenTai下载的画廊(当做本地阅览器)。将你的画廊放在默认下载路径下，之后刷新即可',
       'deleteLocalGalleryHint': '删除您的本地文件',
       'priority': '优先级',
       'highest': '最高',
@@ -620,7 +635,8 @@ class zh_CN {
       'peakHoursHint': '高峰段下载原图需要耗费GP，由于你的GP不足，下载已自动停止。',
       'oldGalleryHint': '部分画廊下载原图需要耗费GP，由于你的GP不足，下载已自动停止。',
       'exceedLimitHint': '图片配额已耗尽，由于你的GP不足，下载已自动停止。',
-      'deleteUpdatingDependentHint': '有其他画廊的更新依赖当前画廊，此时删除会影响其他画廊的更新速度，推荐在更新完毕后再执行删除操作。',
+      'deleteUpdatingDependentHint':
+          '有其他画廊的更新依赖当前画廊，此时删除会影响其他画廊的更新速度，推荐在更新完毕后再执行删除操作。',
       'migrateToDownload': '迁移至「下载」',
       'refresh': '刷新',
 
@@ -661,7 +677,8 @@ class zh_CN {
       'pageAtLeast': '页数至少',
       'pageAtMost': '页数最多',
       'pagesBetween': '页数范围',
-      'pageRangeSelectHint': 'min <= 1000, max >= 10\nmin/max <= 0.8, max-min >= 20',
+      'pageRangeSelectHint':
+          'min <= 1000, max >= 10\nmin/max <= 0.8, max-min >= 20',
       'to': '到',
       'minimumRating': '最低评分',
       'disableFilterForLanguage': '禁用语言过滤',
@@ -710,7 +727,8 @@ favnote：匹配收藏备注
 
       /// download setting page
       'downloadPath': '下载路径',
-      'changeDownloadPathHint': '长按来改变下载路径(请不要使用SD卡或系统路径)。会自动复制已下载的画廊到新路径，并保留原文件。如果你遇到相关错误，请尝试重置路径',
+      'changeDownloadPathHint':
+          '长按来改变下载路径(请不要使用SD卡或系统路径)。会自动复制已下载的画廊到新路径，并保留原文件。如果你遇到相关错误，请尝试重置路径',
       'resetDownloadPath': '重置下载路径',
       'singleImageSavePath': '单张图片保存路径',
       'extraGalleryScanPath': '额外的画廊扫描路径',
@@ -736,7 +754,8 @@ favnote：匹配收藏备注
       'per': '每',
       'images': '图片',
       'downloadAllGallerysOfSamePriority': '同一优先级下同时下载所有画廊',
-      'downloadAllGallerysOfSamePriorityHint': '默认情况下逐优先级下载画廊，且每个优先级下只会同时下载一个画廊',
+      'downloadAllGallerysOfSamePriorityHint':
+          '默认情况下逐优先级下载画廊，且每个优先级下只会同时下载一个画廊',
       'alwaysUseDefaultGroup': '总是使用默认分组',
       'restoreDownloadTasks': '恢复下载任务',
       'enableStoreMetadataForRestore': '允许储存下载元数据用来恢复下载记录',

--- a/lib/src/l18n/zh_TW.dart
+++ b/lib/src/l18n/zh_TW.dart
@@ -90,8 +90,10 @@ class zh_TW {
       'refreshIgneousFailed': '重新整理Igneous失敗',
 
       /// request
-      'sadPanda': 'Sad Panda(無響應資料). 解決參考Github Wiki: https://github.com/jiangtian616/JHenTai/wiki/%E5%B8%B8%E8%A7%81%E9%97%AE%E9%A2%98',
-      'sadPandaReferLink': 'https://github.com/jiangtian616/JHenTai/wiki/%E5%B8%B8%E8%A7%81%E9%97%AE%E9%A2%98',
+      'sadPanda':
+          'Sad Panda(無響應資料). 解決參考Github Wiki: https://github.com/jiangtian616/JHenTai/wiki/%E5%B8%B8%E8%A7%81%E9%97%AE%E9%A2%98',
+      'sadPandaReferLink':
+          'https://github.com/jiangtian616/JHenTai/wiki/%E5%B8%B8%E8%A7%81%E9%97%AE%E9%A2%98',
 
       /// gallery card
       'filtered': '已過濾',
@@ -164,7 +166,8 @@ class zh_TW {
       'score': '分數',
       'NotOnTheList': '未上榜',
       'getGalleryArchiveFailed': '獲取歸檔資料失敗',
-      'parseGalleryArchiveFailed': '解析錯誤，確保你e站的[Archiver Settings]設定的是[Manual Select, Manual Start (Default)]',
+      'parseGalleryArchiveFailed':
+          '解析錯誤，確保你e站的[Archiver Settings]設定的是[Manual Select, Manual Start (Default)]',
       'original': '原圖',
       'resample': '壓縮',
       'beginToDownloadArchive': '開始下載歸檔',
@@ -221,7 +224,8 @@ class zh_TW {
       'paused': '已暫停',
       'exceedImageLimits': "超出圖片配額限制",
       'ehServerError': 'E站伺服器發生錯誤，請稍後重試',
-      'unsupportedImagePageStyle': "JHenTai目前不支援Multi-Page Viewer(MPV)多頁查看，請在e-hentai.org更換為預設風格",
+      'unsupportedImagePageStyle':
+          "JHenTai目前不支援Multi-Page Viewer(MPV)多頁查看，請在e-hentai.org更換為預設風格",
       'toNext': '下一頁',
       'toPrev': '上一頁',
       'back': '返回',
@@ -323,6 +327,8 @@ class zh_TW {
       'followSystem': '跟隨系統',
       'themeColor': '主題顏色',
       'themeColorFixedOnApple': 'macOS / iOS 使用固定強調色',
+      'appleVisualStyle': 'Apple 視覺樣式',
+      'appleVisualStyleHint': '啟用 macOS / iOS 的重新設計介面',
       'listStyle': '畫廊列表樣式(全域)',
       'flat': '平坦',
       'flatWithoutTags': '平坦 - 無標籤',
@@ -431,7 +437,8 @@ class zh_TW {
       'deleteSuperResolvedImage': '刪除圖片超解析度後的圖片',
       'superResolveOriginalImageHint': '處理原圖會耗費更多的時間、空間和性能，確定繼續？',
       'verityAppLinks4Android12': '驗證應用程式連結（安卓12+）',
-      'verityAppLinks4Android12Hint': '對於Android 12+，您需要手動新增連結到已驗證連結才能在其他程式中喚起JHenTai',
+      'verityAppLinks4Android12Hint':
+          '對於Android 12+，您需要手動新增連結到已驗證連結才能在其他程式中喚起JHenTai',
       'noImageMode': '無圖模式',
       'exportData': '匯出資料',
       'exportDataHint': '匯出設定、隱藏規則與歷史記錄',
@@ -502,7 +509,8 @@ class zh_TW {
       'left2rightList': '從左至右(連續)',
       'right2leftList': '從右至左(連續)',
       'enablePageTurnByVolumeKeys': '使用音量鍵翻頁',
-      'enablePageTurnByVolumeKeysHint': 'iOS 上，若音量為 0 或 100%，進入閱讀頁時音量將被自動調整以支援翻頁，退出後恢復',
+      'enablePageTurnByVolumeKeysHint':
+          'iOS 上，若音量為 0 或 100%，進入閱讀頁時音量將被自動調整以支援翻頁，退出後恢復',
       'enablePageTurnAnime': '開啟翻頁動畫',
       'enableDoubleTapToScaleUp': '允許雙擊放大圖片',
       'enableTapDragToScaleUp': '允許單擊後拖曳放大圖片',
@@ -522,6 +530,11 @@ class zh_TW {
       'ScreenHeight': '螢幕',
       'preloadPageCount': '預先載入圖片數量(線上模式)',
       'preloadPageCountInLocalMode': '預先載入圖片數量(本機模式)',
+      'failedImageRetryScope': "失敗圖片重試範圍",
+      'failedImageRetryScopeHint': "點擊載入失敗的線上圖片進行重試時，一次重試的範圍",
+      'retrySingleImage': "僅目前圖片",
+      'retryCurrentPageAndAfter': "目前圖片及之後",
+      'retryAllFailedImages': "全部失敗圖片",
       'continuousScroll': '連續滾動',
       'continuousScrollHint': '拼接多個圖片',
       'doubleColumn': '雙列模式',
@@ -588,8 +601,10 @@ class zh_TW {
       'reUnlock': '重新解鎖',
       'reUnlockHint': '注意！重新解鎖需要重新購買此歸檔！',
       'downloadHelpInfo': '如果發現無法下載，在日誌中發現了資料庫表不存在等問題，移除目前app重裝即可。',
-      'localGalleryHelpInfo': '載入那些不是由JHenTai下載的畫廊(當做本機閱覽器)。在下載設定-額外的畫廊掃描路徑中設定，之後重新整理即可',
-      'localGalleryHelpInfo4iOSAndMacOS': '載入那些不是由JHenTai下載的畫廊(當做本機閱覽器)。將你的畫廊放在預設下載路徑下，之後重新整理即可',
+      'localGalleryHelpInfo':
+          '載入那些不是由JHenTai下載的畫廊(當做本機閱覽器)。在下載設定-額外的畫廊掃描路徑中設定，之後重新整理即可',
+      'localGalleryHelpInfo4iOSAndMacOS':
+          '載入那些不是由JHenTai下載的畫廊(當做本機閱覽器)。將你的畫廊放在預設下載路徑下，之後重新整理即可',
       'deleteLocalGalleryHint': '刪除您的本機文件',
       'priority': '優先度',
       'highest': '最高',
@@ -620,7 +635,8 @@ class zh_TW {
       'peakHoursHint': '尖峰時段下載原圖需要耗費GP，由於你的GP不足，下載已自動停止。',
       'oldGalleryHint': '部分畫廊下載原圖需要耗費GP，由於你的GP不足，下載已自動停止。',
       'exceedLimitHint': '圖片配額已耗盡，由於你的GP不足，下載已自動停止。',
-      'deleteUpdatingDependentHint': '有其他畫廊的更新依賴目前畫廊，此時刪除會影響其他畫廊的更新速度，推薦在更新完畢後再執行刪除操作。',
+      'deleteUpdatingDependentHint':
+          '有其他畫廊的更新依賴目前畫廊，此時刪除會影響其他畫廊的更新速度，推薦在更新完畢後再執行刪除操作。',
       'migrateToDownload': '遷移至「下載」',
       'refresh': '重新整理',
 
@@ -661,7 +677,8 @@ class zh_TW {
       'pageAtLeast': '頁數至少',
       'pageAtMost': '頁數最多',
       'pagesBetween': '頁數範圍',
-      'pageRangeSelectHint': 'min <= 1000, max >= 10\nmin/max <= 0.8, max-min >= 20',
+      'pageRangeSelectHint':
+          'min <= 1000, max >= 10\nmin/max <= 0.8, max-min >= 20',
       'to': '到',
       'minimumRating': '最低評分',
       'disableFilterForLanguage': '停用語言過濾',
@@ -710,7 +727,8 @@ favnote：配對收藏備註
 
       /// download setting page
       'downloadPath': '下載路徑',
-      'changeDownloadPathHint': '長按來改變下載路徑(請不要使用SD卡或系統路徑)。會自動複製已下載的畫廊到新路徑，並保留原文件。如果你遇到相關錯誤，請嘗試重設路徑',
+      'changeDownloadPathHint':
+          '長按來改變下載路徑(請不要使用SD卡或系統路徑)。會自動複製已下載的畫廊到新路徑，並保留原文件。如果你遇到相關錯誤，請嘗試重設路徑',
       'resetDownloadPath': '重設下載路徑',
       'singleImageSavePath': '單張圖片儲存路徑',
       'extraGalleryScanPath': '額外的畫廊掃描路徑',
@@ -736,7 +754,8 @@ favnote：配對收藏備註
       'per': '每',
       'images': '圖片',
       'downloadAllGallerysOfSamePriority': '同一優先度時同時下載所有畫廊',
-      'downloadAllGallerysOfSamePriorityHint': '預設情況下依優先度下載畫廊，且每個優先度下只會同時下載一個畫廊',
+      'downloadAllGallerysOfSamePriorityHint':
+          '預設情況下依優先度下載畫廊，且每個優先度下只會同時下載一個畫廊',
       'alwaysUseDefaultGroup': '總是使用預設分組',
       'restoreDownloadTasks': '復原下載任務',
       'enableStoreMetadataForRestore': '允許儲存下載的中繼資料用來復原下載記錄',

--- a/lib/src/l18n/zh_TW.dart
+++ b/lib/src/l18n/zh_TW.dart
@@ -322,6 +322,7 @@ class zh_TW {
       'light': '明亮',
       'followSystem': '跟隨系統',
       'themeColor': '主題顏色',
+      'themeColorFixedOnApple': 'macOS / iOS 使用固定強調色',
       'listStyle': '畫廊列表樣式(全域)',
       'flat': '平坦',
       'flatWithoutTags': '平坦 - 無標籤',

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -8,6 +8,7 @@ import 'package:get/get.dart';
 import 'package:jhentai/src/l18n/locale_text.dart';
 import 'package:jhentai/src/network/eh_request.dart';
 import 'package:jhentai/src/network/jh_request.dart';
+import 'package:macos_window_utils/macos_window_utils.dart';
 import 'package:jhentai/src/routes/getx_router_observer.dart';
 import 'package:jhentai/src/routes/routes.dart';
 import 'package:jhentai/src/service/app_update_service.dart';
@@ -108,6 +109,10 @@ void main(List<String> args) async {
   }
 
   WidgetsFlutterBinding.ensureInitialized();
+
+  if (GetPlatform.isMacOS) {
+    await WindowManipulator.initialize();
+  }
 
   SystemChrome.setSystemUIOverlayStyle(const SystemUiOverlayStyle(
     systemNavigationBarColor: Colors.transparent,

--- a/lib/src/mixin/scroll_to_top_page_mixin.dart
+++ b/lib/src/mixin/scroll_to_top_page_mixin.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:get/get_state_manager/src/simple/get_state.dart';
+import 'package:get/get.dart';
+import 'package:jhentai/src/config/ui_config.dart';
 import 'package:jhentai/src/mixin/scroll_to_top_logic_mixin.dart';
 import 'package:jhentai/src/mixin/scroll_to_top_state_mixin.dart';
 
@@ -14,15 +15,23 @@ mixin Scroll2TopPageMixin on Widget {
       global: false,
       init: scroll2TopLogic,
       builder: (_) {
-        return AnimatedSwitcher(
-          duration: const Duration(milliseconds: 200),
-          child: scroll2TopLogic.shouldDisplayFAB
-              ? FloatingActionButton(
-                  child: const Icon(Icons.arrow_upward),
-                  heroTag: null,
-                  onPressed: scroll2TopLogic.scroll2Top,
-                )
-              : null,
+        final appContext = Get.context;
+        return Padding(
+          padding: EdgeInsets.only(
+            bottom: appContext == null
+                ? 0
+                : UIConfig.liquidGlassNavBarRaise(appContext),
+          ),
+          child: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 200),
+            child: scroll2TopLogic.shouldDisplayFAB
+                ? FloatingActionButton(
+                    child: const Icon(Icons.arrow_upward),
+                    heroTag: null,
+                    onPressed: scroll2TopLogic.scroll2Top,
+                  )
+                : null,
+          ),
         );
       },
     );

--- a/lib/src/mixin/window_widget_mixin.dart
+++ b/lib/src/mixin/window_widget_mixin.dart
@@ -137,18 +137,9 @@ mixin WindowWidgetMixin<T extends StatefulWidget> on State<T>, WindowListener {
   }
 
   Widget buildMaxOSTitle(Widget child) {
-    return Column(
-      children: [
-        /// Theme-colored translucent strip under the native traffic lights
-        /// (full-size content view), matching the sidebar's frosted look —
-        /// the frosted window shows through the semi-transparent tint.
-        Container(
-          height: UIConfig.desktopTitleBarHeight,
-          color: (titleBarColor ?? UIConfig.backGroundColor(context)).withValues(alpha: 0.55),
-        ),
-        Expanded(child: child),
-      ],
-    );
+    /// The macOS full-size content view is intentionally allowed to reach the
+    /// top edge. The desktop sidebar reserves the traffic-light area itself.
+    return child;
   }
 
   Future<void> toggleFullScreen() async {

--- a/lib/src/mixin/window_widget_mixin.dart
+++ b/lib/src/mixin/window_widget_mixin.dart
@@ -139,7 +139,13 @@ mixin WindowWidgetMixin<T extends StatefulWidget> on State<T>, WindowListener {
   Widget buildMaxOSTitle(Widget child) {
     return Column(
       children: [
-        Container(height: 8, color: titleBarColor ?? UIConfig.backGroundColor(context)),
+        /// Theme-colored translucent strip under the native traffic lights
+        /// (full-size content view), matching the sidebar's frosted look —
+        /// the frosted window shows through the semi-transparent tint.
+        Container(
+          height: UIConfig.desktopTitleBarHeight,
+          color: (titleBarColor ?? UIConfig.backGroundColor(context)).withValues(alpha: 0.55),
+        ),
         Expanded(child: child),
       ],
     );

--- a/lib/src/pages/base/base_page.dart
+++ b/lib/src/pages/base/base_page.dart
@@ -4,6 +4,7 @@ import 'package:get/get.dart';
 import 'package:jhentai/src/pages/layout/mobile_v2/notification/tap_menu_button_notification.dart';
 import 'package:jhentai/src/setting/style_setting.dart';
 import 'package:jhentai/src/service/log.dart';
+import 'package:jhentai/src/utils/app_icons.dart';
 import 'package:jhentai/src/widget/eh_wheel_speed_controller.dart';
 
 import '../../config/ui_config.dart';
@@ -69,7 +70,7 @@ abstract class BasePage<L extends BasePageLogic, S extends BasePageState> extend
 
   Widget buildAppBarMenuButton(BuildContext context) {
     return IconButton(
-      icon: Icon(Icons.menu, size: 20),
+      icon: Icon(AppIcons.menu, size: 20),
       onPressed: () => TapMenuButtonNotification().dispatch(context),
     );
   }
@@ -77,8 +78,8 @@ abstract class BasePage<L extends BasePageLogic, S extends BasePageState> extend
   List<Widget> buildAppBarActions() {
     return [
       if (showJumpButton && state.gallerys.isNotEmpty)
-        IconButton(icon: Icon(Icons.send, size: 20), onPressed: logic.handleTapJumpButton),
-      if (showFilterButton) IconButton(icon: const Icon(Icons.filter_alt_outlined, size: 28), onPressed: logic.handleTapFilterButton),
+        IconButton(icon: Icon(AppIcons.jump, size: 20), onPressed: logic.handleTapJumpButton),
+      if (showFilterButton) IconButton(icon: Icon(AppIcons.filter, size: 28), onPressed: logic.handleTapFilterButton),
     ];
   }
 
@@ -105,7 +106,7 @@ abstract class BasePage<L extends BasePageLogic, S extends BasePageState> extend
                   slivers: <Widget>[
                     buildPullDownIndicator(),
                     buildGalleryCollection(context),
-                    buildLoadMoreIndicator(),
+                    buildLoadMoreIndicator(context),
                   ],
                 ),
               ),
@@ -141,9 +142,9 @@ abstract class BasePage<L extends BasePageLogic, S extends BasePageState> extend
     );
   }
 
-  Widget buildLoadMoreIndicator() {
+  Widget buildLoadMoreIndicator(BuildContext context) {
     return SliverPadding(
-      padding: const EdgeInsets.only(top: 16, bottom: 40),
+      padding: EdgeInsets.only(top: 16, bottom: 40 + UIConfig.liquidGlassNavContentInset(context)),
       sliver: SliverToBoxAdapter(
         child: GetBuilder<L>(
           id: logic.loadingStateId,

--- a/lib/src/pages/base/base_page.dart
+++ b/lib/src/pages/base/base_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:jhentai/src/config/theme_config.dart';
 import 'package:jhentai/src/pages/layout/mobile_v2/notification/tap_menu_button_notification.dart';
 import 'package:jhentai/src/setting/style_setting.dart';
 import 'package:jhentai/src/service/log.dart';
@@ -16,7 +17,8 @@ import '../../widget/loading_state_indicator.dart';
 import 'base_page_logic.dart';
 import 'base_page_state.dart';
 
-abstract class BasePage<L extends BasePageLogic, S extends BasePageState> extends StatelessWidget with Scroll2TopPageMixin {
+abstract class BasePage<L extends BasePageLogic, S extends BasePageState>
+    extends StatelessWidget with Scroll2TopPageMixin {
   /// For mobile layout v2
   final bool showMenuButton;
   final bool showJumpButton;
@@ -52,9 +54,18 @@ abstract class BasePage<L extends BasePageLogic, S extends BasePageState> extend
       init: logic,
       builder: (_) => Scaffold(
         backgroundColor: UIConfig.backGroundColor(context),
-        appBar: showFilterButton || showJumpButton || showMenuButton || showTitle ? buildAppBar(context) : null,
-        body: SafeArea(child: buildBody(context)),
-        floatingActionButton: showScroll2TopButton ? buildFloatingActionButton() : null,
+        appBar:
+            showFilterButton || showJumpButton || showMenuButton || showTitle
+                ? buildAppBar(context)
+                : null,
+        // Let Apple mobile content continue behind the floating bar instead
+        // of leaving a separately colored bottom safe-area strip.
+        body: SafeArea(
+          bottom: !(ThemeConfig.isApple && styleSetting.isInMobileLayout),
+          child: buildBody(context),
+        ),
+        floatingActionButton:
+            showScroll2TopButton ? buildFloatingActionButton() : null,
       ),
     );
   }
@@ -78,8 +89,13 @@ abstract class BasePage<L extends BasePageLogic, S extends BasePageState> extend
   List<Widget> buildAppBarActions() {
     return [
       if (showJumpButton && state.gallerys.isNotEmpty)
-        IconButton(icon: Icon(AppIcons.jump, size: 20), onPressed: logic.handleTapJumpButton),
-      if (showFilterButton) IconButton(icon: Icon(AppIcons.filter, size: 28), onPressed: logic.handleTapFilterButton),
+        IconButton(
+            icon: Icon(AppIcons.jump, size: 20),
+            onPressed: logic.handleTapJumpButton),
+      if (showFilterButton)
+        IconButton(
+            icon: Icon(AppIcons.filter, size: 28),
+            onPressed: logic.handleTapFilterButton),
     ];
   }
 
@@ -92,25 +108,28 @@ abstract class BasePage<L extends BasePageLogic, S extends BasePageState> extend
       id: logic.bodyId,
       global: false,
       init: logic,
-      builder: (_) => state.gallerys.isEmpty && state.loadingState != LoadingState.idle
-          ? buildCenterStatusIndicator()
-          : NotificationListener<UserScrollNotification>(
-              onNotification: logic.onUserScroll,
-              child: EHWheelSpeedController(
-                controller: state.scrollController,
-                child: CustomScrollView(
-                  key: state.pageStorageKey,
-                  controller: state.scrollController,
-                  physics: const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
-                  scrollBehavior: UIConfig.scrollBehaviourWithScrollBarWithMouse,
-                  slivers: <Widget>[
-                    buildPullDownIndicator(),
-                    buildGalleryCollection(context),
-                    buildLoadMoreIndicator(context),
-                  ],
+      builder: (_) =>
+          state.gallerys.isEmpty && state.loadingState != LoadingState.idle
+              ? buildCenterStatusIndicator()
+              : NotificationListener<UserScrollNotification>(
+                  onNotification: logic.onUserScroll,
+                  child: EHWheelSpeedController(
+                    controller: state.scrollController,
+                    child: CustomScrollView(
+                      key: state.pageStorageKey,
+                      controller: state.scrollController,
+                      physics: const BouncingScrollPhysics(
+                          parent: AlwaysScrollableScrollPhysics()),
+                      scrollBehavior:
+                          UIConfig.scrollBehaviourWithScrollBarWithMouse,
+                      slivers: <Widget>[
+                        buildPullDownIndicator(),
+                        buildGalleryCollection(context),
+                        buildLoadMoreIndicator(context),
+                      ],
+                    ),
+                  ),
                 ),
-              ),
-            ),
     );
   }
 
@@ -144,7 +163,8 @@ abstract class BasePage<L extends BasePageLogic, S extends BasePageState> extend
 
   Widget buildLoadMoreIndicator(BuildContext context) {
     return SliverPadding(
-      padding: EdgeInsets.only(top: 16, bottom: 40 + UIConfig.liquidGlassNavContentInset(context)),
+      padding: EdgeInsets.only(
+          top: 16, bottom: 40 + UIConfig.liquidGlassNavContentInset(context)),
       sliver: SliverToBoxAdapter(
         child: GetBuilder<L>(
           id: logic.loadingStateId,
@@ -168,11 +188,14 @@ abstract class BasePage<L extends BasePageLogic, S extends BasePageState> extend
         key: state.galleryCollectionKey,
         context: context,
         gallerys: state.gallerys,
-        listMode: styleSetting.pageListMode[state.route] ?? styleSetting.listMode.value,
+        listMode: styleSetting.pageListMode[state.route] ??
+            styleSetting.listMode.value,
         loadingState: state.loadingState,
         handleTapCard: logic.handleTapGalleryCard,
-        handleLongPressCard: (gallery, position) => logic.handleLongPressCard(context, gallery, position: position),
-        handleSecondaryTapCard: (gallery, position) => logic.handleSecondaryTapCard(context, gallery, position: position),
+        handleLongPressCard: (gallery, position) =>
+            logic.handleLongPressCard(context, gallery, position: position),
+        handleSecondaryTapCard: (gallery, position) =>
+            logic.handleSecondaryTapCard(context, gallery, position: position),
         handleLoadMore: logic.loadMore,
       ),
     );

--- a/lib/src/pages/blank_page.dart
+++ b/lib/src/pages/blank_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:jhentai/src/config/theme_config.dart';
 import 'package:jhentai/src/config/ui_config.dart';
 
 class BlankPage extends StatelessWidget {
@@ -10,8 +11,11 @@ class BlankPage extends StatelessWidget {
       color: UIConfig.backGroundColor(context),
       child: Center(
         child: Text(
-          'J',
-          style: TextStyle(color: UIConfig.jHentaiIconColor(context), fontSize: 120, fontWeight: FontWeight.w600),
+          ThemeConfig.isApple ? 'JHenTai' : 'J',
+          style: TextStyle(
+              color: UIConfig.jHentaiIconColor(context),
+              fontSize: 120,
+              fontWeight: FontWeight.w600),
         ),
       ),
     );

--- a/lib/src/pages/details/details_page.dart
+++ b/lib/src/pages/details/details_page.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_rating_bar/flutter_rating_bar.dart';
 import 'package:get/get.dart';
+import 'package:jhentai/src/config/theme_config.dart';
 import 'package:jhentai/src/config/ui_config.dart';
 import 'package:jhentai/src/enum/eh_namespace.dart';
 import 'package:jhentai/src/extension/string_extension.dart';
@@ -81,7 +82,8 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
         id: DetailsPageLogic.galleryId,
         global: false,
         init: logic,
-        builder: (_) => Text(logic.mainTitleText.breakWord, style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold)),
+        builder: (_) => Text(logic.mainTitleText.breakWord,
+            style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold)),
       ),
       actions: [
         _buildMenuButton(context),
@@ -104,8 +106,10 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
           builder: (_) => GetBuilder<GalleryDownloadService>(
             id: '${galleryDownloadService.galleryDownloadProgressId}::${state.galleryUrl.gid}',
             builder: (_) {
-              bool containGallery = galleryDownloadService.containGallery(state.galleryUrl.gid);
-              bool containArchive = archiveDownloadService.containArchive(state.galleryUrl.gid);
+              bool containGallery =
+                  galleryDownloadService.containGallery(state.galleryUrl.gid);
+              bool containArchive =
+                  archiveDownloadService.containArchive(state.galleryUrl.gid);
 
               return PopupMenuButton(
                 itemBuilder: (context) {
@@ -115,7 +119,10 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
                         value: 0,
                         child: Row(
                           mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [Text('jump'.tr), Icon(Icons.send, size: 20)],
+                          children: [
+                            Text('jump'.tr),
+                            Icon(Icons.send, size: 20)
+                          ],
                         ),
                       ),
                     PopupMenuItem(
@@ -130,7 +137,10 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
                         value: 2,
                         child: Row(
                           mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [Text('addTag'.tr), const Icon(Icons.bookmark_border)],
+                          children: [
+                            Text('addTag'.tr),
+                            const Icon(Icons.bookmark_border)
+                          ],
                         ),
                       ),
                     if (containGallery || containArchive)
@@ -138,15 +148,23 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
                         value: 3,
                         child: Row(
                           mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [Text('delete'.tr), const Icon(Icons.delete)],
+                          children: [
+                            Text('delete'.tr),
+                            const Icon(Icons.delete)
+                          ],
                         ),
                       ),
-                    if (state.galleryDetails?.parentGalleryUrl != null || (state.galleryDetails?.childrenGallerys?.isNotEmpty ?? false))
+                    if (state.galleryDetails?.parentGalleryUrl != null ||
+                        (state.galleryDetails?.childrenGallerys?.isNotEmpty ??
+                            false))
                       PopupMenuItem(
                         value: 4,
                         child: Row(
                           mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [Text('history'.tr), const Icon(Icons.history)],
+                          children: [
+                            Text('history'.tr),
+                            const Icon(Icons.history)
+                          ],
                         ),
                       ),
                     if (state.galleryDetails != null)
@@ -161,7 +179,10 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
                       value: 6,
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [Text('resetReadProgress'.tr), const Icon(Icons.restore)],
+                        children: [
+                          Text('resetReadProgress'.tr),
+                          const Icon(Icons.restore)
+                        ],
                       ),
                     ),
                   ];
@@ -180,7 +201,9 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
                     logic.handleTapDeleteDownload(
                       context,
                       state.galleryUrl.gid,
-                      containGallery ? DownloadPageGalleryType.download : DownloadPageGalleryType.archive,
+                      containGallery
+                          ? DownloadPageGalleryType.download
+                          : DownloadPageGalleryType.archive,
                     );
                   }
                   if (value == 4) {
@@ -207,13 +230,15 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
       child: EHWheelSpeedController(
         controller: state.scrollController,
         child: CustomScrollView(
-          physics: const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
+          physics: const BouncingScrollPhysics(
+              parent: AlwaysScrollableScrollPhysics()),
           scrollBehavior: UIConfig.scrollBehaviourWithScrollBarWithMouse,
           controller: state.scrollController,
           scrollCacheExtent: ScrollCacheExtent.pixels(5000),
           slivers: [
             CupertinoSliverRefreshControl(onRefresh: logic.handleRefresh),
-            if (preferenceSetting.showAllGalleryTitles.isTrue) _buildSubTitle(context),
+            if (preferenceSetting.showAllGalleryTitles.isTrue)
+              _buildSubTitle(context),
             buildDetail(context),
             buildDivider(),
             buildNewVersionHint(),
@@ -234,7 +259,10 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
     return SliverToBoxAdapter(
       child: Container(
         height: UIConfig.detailsPageHeaderHeight,
-        margin: const EdgeInsets.only(top: 12, left: UIConfig.detailPagePadding, right: UIConfig.detailPagePadding),
+        margin: const EdgeInsets.only(
+            top: 12,
+            left: UIConfig.detailPagePadding,
+            right: UIConfig.detailPagePadding),
         child: Row(
           children: [
             _buildCover(context),
@@ -252,7 +280,9 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
       global: false,
       init: logic,
       builder: (_) {
-        GalleryImage? cover = state.galleryDetails?.cover ?? state.gallery?.cover ?? state.galleryMetadata?.cover;
+        GalleryImage? cover = state.galleryDetails?.cover ??
+            state.gallery?.cover ??
+            state.galleryMetadata?.cover;
 
         if (cover == null) {
           return Container(
@@ -269,15 +299,19 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
             galleryImage: cover,
             containerHeight: UIConfig.detailsPageCoverHeight,
             containerWidth: UIConfig.detailsPageCoverWidth,
-            borderRadius: BorderRadius.circular(UIConfig.detailsPageCoverBorderRadius),
+            borderRadius: BorderRadius.circular(ThemeConfig.isApple
+                ? 8
+                : UIConfig.detailsPageCoverBorderRadius),
             heroTag: cover,
-            shadows: [
-              BoxShadow(
-                color: UIConfig.detailPageCoverShadowColor(context),
-                blurRadius: 5,
-                offset: const Offset(3, 5),
-              ),
-            ],
+            shadows: ThemeConfig.isApple
+                ? null
+                : [
+                    BoxShadow(
+                      color: UIConfig.detailPageCoverShadowColor(context),
+                      blurRadius: 5,
+                      offset: const Offset(3, 5),
+                    ),
+                  ],
           ),
         );
       },
@@ -314,20 +348,26 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
             letterSpacing: UIConfig.detailsPageTitleLetterSpacing,
             height: UIConfig.detailsPageTitleTextHeight,
           ),
-          contextMenuBuilder: (BuildContext context, EditableTextState editableTextState) {
-            AdaptiveTextSelectionToolbar toolbar = AdaptiveTextSelectionToolbar.buttonItems(
+          contextMenuBuilder:
+              (BuildContext context, EditableTextState editableTextState) {
+            AdaptiveTextSelectionToolbar toolbar =
+                AdaptiveTextSelectionToolbar.buttonItems(
               buttonItems: editableTextState.contextMenuButtonItems,
               anchors: editableTextState.contextMenuAnchors,
             );
 
-            if (!editableTextState.currentTextEditingValue.selection.isCollapsed) {
+            if (!editableTextState
+                .currentTextEditingValue.selection.isCollapsed) {
               toolbar.buttonItems?.add(
                 ContextMenuButtonItem(
                   label: 'search'.tr,
                   onPressed: () {
                     ContextMenuController.removeAny();
                     newSearch(
-                      keyword: editableTextState.currentTextEditingValue.selection.textInside(editableTextState.currentTextEditingValue.text),
+                      keyword: editableTextState
+                          .currentTextEditingValue.selection
+                          .textInside(
+                              editableTextState.currentTextEditingValue.text),
                       forceNewRoute: true,
                     );
                   },
@@ -346,7 +386,8 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
     return SliverToBoxAdapter(
       child: Container(
         height: 28,
-        padding: const EdgeInsets.symmetric(horizontal: UIConfig.detailPagePadding),
+        padding:
+            const EdgeInsets.symmetric(horizontal: UIConfig.detailPagePadding),
         alignment: Alignment.centerLeft,
         child: GetBuilder<DetailsPageLogic>(
           id: DetailsPageLogic.detailsId,
@@ -354,45 +395,62 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
           init: logic,
           builder: (_) {
             if (state.galleryDetails == null && state.galleryMetadata == null) {
-              return const AnimatedSwitcher(duration: Duration(milliseconds: UIConfig.detailsPageAnimationDuration), child: SizedBox());
+              return const AnimatedSwitcher(
+                  duration: Duration(
+                      milliseconds: UIConfig.detailsPageAnimationDuration),
+                  child: SizedBox());
             }
 
             String? subTitle;
-            if (state.galleryDetails?.japaneseTitle != null && state.galleryDetails!.japaneseTitle! != logic.mainTitleText) {
+            if (state.galleryDetails?.japaneseTitle != null &&
+                state.galleryDetails!.japaneseTitle! != logic.mainTitleText) {
               subTitle = state.galleryDetails!.japaneseTitle;
-            } else if (state.galleryDetails?.rawTitle != null && state.galleryDetails!.rawTitle != logic.mainTitleText) {
+            } else if (state.galleryDetails?.rawTitle != null &&
+                state.galleryDetails!.rawTitle != logic.mainTitleText) {
               subTitle = state.galleryDetails!.rawTitle;
-            } else if (state.galleryMetadata?.title != null && state.galleryMetadata!.title != logic.mainTitleText) {
+            } else if (state.galleryMetadata?.title != null &&
+                state.galleryMetadata!.title != logic.mainTitleText) {
               subTitle = state.galleryMetadata!.title;
-            } else if (state.galleryMetadata?.japaneseTitle != null && state.galleryMetadata!.japaneseTitle != logic.mainTitleText) {
+            } else if (state.galleryMetadata?.japaneseTitle != null &&
+                state.galleryMetadata!.japaneseTitle != logic.mainTitleText) {
               subTitle = state.galleryMetadata!.japaneseTitle;
             }
 
             if (subTitle == null) {
-              return const AnimatedSwitcher(duration: Duration(milliseconds: UIConfig.detailsPageAnimationDuration), child: SizedBox());
+              return const AnimatedSwitcher(
+                  duration: Duration(
+                      milliseconds: UIConfig.detailsPageAnimationDuration),
+                  child: SizedBox());
             }
 
             return AnimatedSwitcher(
-              duration: const Duration(milliseconds: UIConfig.detailsPageAnimationDuration),
+              duration: const Duration(
+                  milliseconds: UIConfig.detailsPageAnimationDuration),
               child: SelectableText(
                 subTitle,
                 minLines: 1,
                 maxLines: 2,
                 style: UIConfig.detailsPageSubTitleTextStyle(context),
-                contextMenuBuilder: (BuildContext context, EditableTextState editableTextState) {
-                  AdaptiveTextSelectionToolbar toolbar = AdaptiveTextSelectionToolbar.buttonItems(
+                contextMenuBuilder: (BuildContext context,
+                    EditableTextState editableTextState) {
+                  AdaptiveTextSelectionToolbar toolbar =
+                      AdaptiveTextSelectionToolbar.buttonItems(
                     buttonItems: editableTextState.contextMenuButtonItems,
                     anchors: editableTextState.contextMenuAnchors,
                   );
 
-                  if (!editableTextState.currentTextEditingValue.selection.isCollapsed) {
+                  if (!editableTextState
+                      .currentTextEditingValue.selection.isCollapsed) {
                     toolbar.buttonItems?.add(
                       ContextMenuButtonItem(
                         label: 'search'.tr,
                         onPressed: () {
                           ContextMenuController.removeAny();
                           newSearch(
-                            keyword: editableTextState.currentTextEditingValue.selection.textInside(editableTextState.currentTextEditingValue.text),
+                            keyword: editableTextState
+                                .currentTextEditingValue.selection
+                                .textInside(editableTextState
+                                    .currentTextEditingValue.text),
                             forceNewRoute: true,
                           );
                         },
@@ -420,17 +478,24 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
           onLongPress: isEmptyOrNull(logic.uploader)
               ? null
               : () async {
-                  bool? result = await showDialog(context: context, builder: (_) => EHDialog(title: 'blockUploaderLocally'.tr + '?'));
+                  bool? result = await showDialog(
+                      context: context,
+                      builder: (_) =>
+                          EHDialog(title: 'blockUploaderLocally'.tr + '?'));
                   if (result == true) {
                     logic.blockUploader(logic.uploader);
                   }
                 },
           child: SelectableText(
             logic.uploader,
-            style: TextStyle(fontSize: UIConfig.detailsPageUploaderTextSize, color: UIConfig.detailsPageUploaderTextColor(context)),
+            style: TextStyle(
+                fontSize: UIConfig.detailsPageUploaderTextSize,
+                color: UIConfig.detailsPageUploaderTextColor(context)),
             onTap: logic.searchUploader,
-            contextMenuBuilder: (BuildContext context, EditableTextState editableTextState) {
-              AdaptiveTextSelectionToolbar toolbar = AdaptiveTextSelectionToolbar.editableText(
+            contextMenuBuilder:
+                (BuildContext context, EditableTextState editableTextState) {
+              AdaptiveTextSelectionToolbar toolbar =
+                  AdaptiveTextSelectionToolbar.editableText(
                 editableTextState: editableTextState,
               );
 
@@ -457,10 +522,13 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
       behavior: HitTestBehavior.opaque,
       onTap: () {
         if (state.galleryDetails != null) {
-          Get.dialog(EHGalleryDetailDialog(galleryDetail: state.galleryDetails!));
+          Get.dialog(
+              EHGalleryDetailDialog(galleryDetail: state.galleryDetails!));
         }
       },
-      child: styleSetting.isInMobileLayout ? _buildInfoInThreeRows(context) : _buildInfoInTwoRows(),
+      child: styleSetting.isInMobileLayout
+          ? _buildInfoInThreeRows(context)
+          : _buildInfoInTwoRows(),
     );
   }
 
@@ -472,23 +540,34 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
         final double space = 4 / 3 + constraints.maxWidth / 300;
 
         return DefaultTextStyle(
-          style: DefaultTextStyle.of(context).style.copyWith(fontSize: textSize),
+          style:
+              DefaultTextStyle.of(context).style.copyWith(fontSize: textSize),
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
               Row(
                 children: [
-                  Expanded(flex: 9, child: _buildLanguage(iconSize, space, context)),
-                  Expanded(flex: 7, child: _buildFavoriteCount(iconSize, space, context)),
-                  Expanded(flex: 10, child: _buildSize(iconSize, space, context)),
+                  Expanded(
+                      flex: 9, child: _buildLanguage(iconSize, space, context)),
+                  Expanded(
+                      flex: 7,
+                      child: _buildFavoriteCount(iconSize, space, context)),
+                  Expanded(
+                      flex: 10, child: _buildSize(iconSize, space, context)),
                 ],
               ),
               SizedBox(height: space),
               Row(
                 children: [
-                  Expanded(flex: 9, child: _buildPageCount(iconSize, space, context)),
-                  Expanded(flex: 7, child: _buildRatingCount(iconSize, space, context)),
-                  Expanded(flex: 10, child: _buildPublishTime(iconSize, space, context)),
+                  Expanded(
+                      flex: 9,
+                      child: _buildPageCount(iconSize, space, context)),
+                  Expanded(
+                      flex: 7,
+                      child: _buildRatingCount(iconSize, space, context)),
+                  Expanded(
+                      flex: 10,
+                      child: _buildPublishTime(iconSize, space, context)),
                 ],
               ),
             ],
@@ -556,14 +635,17 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
         return Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.language, size: iconSize, color: UIConfig.detailsPageIconColor(context)),
+            Icon(Icons.language,
+                size: iconSize, color: UIConfig.detailsPageIconColor(context)),
             SizedBox(width: space),
             AnimatedSwitcher(
-              duration: const Duration(milliseconds: UIConfig.detailsPageAnimationDuration),
+              duration: const Duration(
+                  milliseconds: UIConfig.detailsPageAnimationDuration),
               child: Text(
                 language,
                 key: ValueKey(language),
-                style: const TextStyle(fontSize: UIConfig.detailsPageInfoTextSize),
+                style:
+                    const TextStyle(fontSize: UIConfig.detailsPageInfoTextSize),
               ),
             ),
           ],
@@ -572,7 +654,8 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
     );
   }
 
-  Widget _buildFavoriteCount(double iconSize, double space, BuildContext context) {
+  Widget _buildFavoriteCount(
+      double iconSize, double space, BuildContext context) {
     return GetBuilder<DetailsPageLogic>(
       id: DetailsPageLogic.detailsId,
       global: false,
@@ -580,14 +663,18 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
       builder: (_) => Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(Icons.favorite, size: iconSize, color: UIConfig.detailsPageIconColor(context)),
+          Icon(Icons.favorite,
+              size: iconSize, color: UIConfig.detailsPageIconColor(context)),
           SizedBox(width: space),
           AnimatedSwitcher(
-            duration: const Duration(milliseconds: UIConfig.detailsPageAnimationDuration),
+            duration: const Duration(
+                milliseconds: UIConfig.detailsPageAnimationDuration),
             child: Text(
               state.galleryDetails?.favoriteCount.toString() ?? '...',
-              key: ValueKey(state.galleryDetails?.favoriteCount.toString() ?? '...'),
-              style: const TextStyle(fontSize: UIConfig.detailsPageInfoTextSize),
+              key: ValueKey(
+                  state.galleryDetails?.favoriteCount.toString() ?? '...'),
+              style:
+                  const TextStyle(fontSize: UIConfig.detailsPageInfoTextSize),
             ),
           )
         ],
@@ -601,19 +688,23 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
       global: false,
       init: logic,
       builder: (_) {
-        String size = state.galleryDetails?.size ?? state.galleryMetadata?.size ?? '...';
+        String size =
+            state.galleryDetails?.size ?? state.galleryMetadata?.size ?? '...';
 
         return Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.archive, size: iconSize, color: UIConfig.detailsPageIconColor(context)),
+            Icon(Icons.archive,
+                size: iconSize, color: UIConfig.detailsPageIconColor(context)),
             SizedBox(width: space),
             AnimatedSwitcher(
-              duration: const Duration(milliseconds: UIConfig.detailsPageAnimationDuration),
+              duration: const Duration(
+                  milliseconds: UIConfig.detailsPageAnimationDuration),
               child: Text(
                 size,
                 key: ValueKey(size),
-                style: const TextStyle(fontSize: UIConfig.detailsPageInfoTextSize),
+                style:
+                    const TextStyle(fontSize: UIConfig.detailsPageInfoTextSize),
               ),
             )
           ],
@@ -628,20 +719,25 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
       global: false,
       init: logic,
       builder: (_) {
-        String pageCount =
-            state.galleryDetails?.pageCount.toString() ?? state.gallery?.pageCount?.toString() ?? state.galleryMetadata?.pageCount.toString() ?? '...';
+        String pageCount = state.galleryDetails?.pageCount.toString() ??
+            state.gallery?.pageCount?.toString() ??
+            state.galleryMetadata?.pageCount.toString() ??
+            '...';
 
         return Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.collections, size: iconSize, color: UIConfig.detailsPageIconColor(context)),
+            Icon(Icons.collections,
+                size: iconSize, color: UIConfig.detailsPageIconColor(context)),
             SizedBox(width: space),
             AnimatedSwitcher(
-              duration: const Duration(milliseconds: UIConfig.detailsPageAnimationDuration),
+              duration: const Duration(
+                  milliseconds: UIConfig.detailsPageAnimationDuration),
               child: Text(
                 pageCount,
                 key: ValueKey(pageCount),
-                style: const TextStyle(fontSize: UIConfig.detailsPageInfoTextSize),
+                style:
+                    const TextStyle(fontSize: UIConfig.detailsPageInfoTextSize),
               ),
             )
           ],
@@ -650,25 +746,30 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
     );
   }
 
-  Widget _buildRatingCount(double iconSize, double space, BuildContext context) {
+  Widget _buildRatingCount(
+      double iconSize, double space, BuildContext context) {
     return GetBuilder<DetailsPageLogic>(
       id: DetailsPageLogic.detailsId,
       global: false,
       init: logic,
       builder: (_) {
-        String ratingCount = state.galleryDetails?.ratingCount.toString() ?? '...';
+        String ratingCount =
+            state.galleryDetails?.ratingCount.toString() ?? '...';
 
         return Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.star, size: iconSize, color: UIConfig.detailsPageIconColor(context)),
+            Icon(Icons.star,
+                size: iconSize, color: UIConfig.detailsPageIconColor(context)),
             SizedBox(width: space),
             AnimatedSwitcher(
-              duration: const Duration(milliseconds: UIConfig.detailsPageAnimationDuration),
+              duration: const Duration(
+                  milliseconds: UIConfig.detailsPageAnimationDuration),
               child: Text(
                 ratingCount,
                 key: ValueKey(ratingCount),
-                style: const TextStyle(fontSize: UIConfig.detailsPageInfoTextSize),
+                style:
+                    const TextStyle(fontSize: UIConfig.detailsPageInfoTextSize),
               ),
             )
           ],
@@ -677,7 +778,8 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
     );
   }
 
-  Widget _buildPublishTime(double iconSize, double space, BuildContext context) {
+  Widget _buildPublishTime(
+      double iconSize, double space, BuildContext context) {
     return GetBuilder<DetailsPageLogic>(
       id: DetailsPageLogic.galleryId,
       global: false,
@@ -696,14 +798,17 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
         return Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.cloud_upload, size: iconSize, color: UIConfig.detailsPageIconColor(context)),
+            Icon(Icons.cloud_upload,
+                size: iconSize, color: UIConfig.detailsPageIconColor(context)),
             SizedBox(width: space),
             AnimatedSwitcher(
-              duration: const Duration(milliseconds: UIConfig.detailsPageAnimationDuration),
+              duration: const Duration(
+                  milliseconds: UIConfig.detailsPageAnimationDuration),
               child: Text(
                 publishTime,
                 key: ValueKey(publishTime),
-                style: const TextStyle(fontSize: UIConfig.detailsPageInfoTextSize),
+                style:
+                    const TextStyle(fontSize: UIConfig.detailsPageInfoTextSize),
               ),
             )
           ],
@@ -730,11 +835,15 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
       global: false,
       init: logic,
       builder: (_) {
-        bool hasRated = state.galleryDetails?.hasRated ?? state.gallery?.hasRated ?? false;
-        double? rating = state.galleryDetails?.rating ?? state.gallery?.rating ?? state.galleryMetadata?.rating;
+        bool hasRated =
+            state.galleryDetails?.hasRated ?? state.gallery?.hasRated ?? false;
+        double? rating = state.galleryDetails?.rating ??
+            state.gallery?.rating ??
+            state.galleryMetadata?.rating;
 
         return AnimatedSwitcher(
-          duration: const Duration(milliseconds: UIConfig.detailsPageAnimationDuration),
+          duration: const Duration(
+              milliseconds: UIConfig.detailsPageAnimationDuration),
           child: rating == null
               ? RatingBar.builder(
                   unratedColor: UIConfig.galleryRatingStarUnRatedColor(context),
@@ -748,7 +857,8 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
                 )
               : KeyedSubtree(
                   child: RatingBar.builder(
-                    unratedColor: UIConfig.galleryRatingStarUnRatedColor(context),
+                    unratedColor:
+                        UIConfig.galleryRatingStarUnRatedColor(context),
                     initialRating: rating,
                     itemCount: 5,
                     allowHalfRating: true,
@@ -756,7 +866,9 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
                     ignoreGestures: true,
                     itemBuilder: (context, index) => Icon(
                       Icons.star,
-                      color: hasRated ? UIConfig.galleryRatingStarRatedColor(context) : UIConfig.galleryRatingStarColor,
+                      color: hasRated
+                          ? UIConfig.galleryRatingStarRatedColor(context)
+                          : UIConfig.galleryRatingStarColor,
                     ),
                     onRatingUpdate: (_) {},
                   ),
@@ -772,14 +884,18 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
       global: false,
       init: logic,
       builder: (_) {
-        String realRating = state.galleryDetails?.realRating.toString() ?? state.galleryMetadata?.rating.toString() ?? '...';
+        String realRating = state.galleryDetails?.realRating.toString() ??
+            state.galleryMetadata?.rating.toString() ??
+            '...';
 
         return AnimatedSwitcher(
-          duration: const Duration(milliseconds: UIConfig.detailsPageAnimationDuration),
+          duration: const Duration(
+              milliseconds: UIConfig.detailsPageAnimationDuration),
           child: Text(
             realRating,
             key: Key(realRating),
-            style: const TextStyle(fontSize: UIConfig.detailsPageRatingTextSize),
+            style:
+                const TextStyle(fontSize: UIConfig.detailsPageRatingTextSize),
           ),
         );
       },
@@ -792,22 +908,33 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
       global: false,
       init: logic,
       builder: (_) {
-        String? category = state.galleryDetails?.category ?? state.gallery?.category ?? state.galleryMetadata?.category;
+        String? category = state.galleryDetails?.category ??
+            state.gallery?.category ??
+            state.galleryMetadata?.category;
 
         return AnimatedSwitcher(
-          duration: const Duration(milliseconds: UIConfig.detailsPageAnimationDuration),
+          duration: const Duration(
+              milliseconds: UIConfig.detailsPageAnimationDuration),
           child: category == null
               ? const EHGalleryCategoryTag(
                   enabled: false,
                   category: '               ',
-                  padding: EdgeInsets.only(top: 2, bottom: 4, left: 4, right: 4),
-                  textStyle: TextStyle(fontSize: UIConfig.detailsPageRatingTextSize, color: UIConfig.galleryCategoryTagTextColor, height: 1),
+                  padding:
+                      EdgeInsets.only(top: 2, bottom: 4, left: 4, right: 4),
+                  textStyle: TextStyle(
+                      fontSize: UIConfig.detailsPageRatingTextSize,
+                      color: UIConfig.galleryCategoryTagTextColor,
+                      height: 1),
                   borderRadius: 3,
                 )
               : EHGalleryCategoryTag(
                   category: category,
-                  padding: const EdgeInsets.only(top: 2, bottom: 4, left: 4, right: 4),
-                  textStyle: const TextStyle(fontSize: UIConfig.detailsPageRatingTextSize, color: UIConfig.galleryCategoryTagTextColor, height: 1),
+                  padding: const EdgeInsets.only(
+                      top: 2, bottom: 4, left: 4, right: 4),
+                  textStyle: const TextStyle(
+                      fontSize: UIConfig.detailsPageRatingTextSize,
+                      color: UIConfig.galleryCategoryTagTextColor,
+                      height: 1),
                   borderRadius: 3,
                 ),
         );
@@ -817,7 +944,10 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
 
   Widget buildDivider() {
     return const SliverPadding(
-      padding: EdgeInsets.only(top: 16, left: UIConfig.detailPagePadding, right: UIConfig.detailPagePadding),
+      padding: EdgeInsets.only(
+          top: 16,
+          left: UIConfig.detailPagePadding,
+          right: UIConfig.detailPagePadding),
       sliver: SliverToBoxAdapter(child: Divider(height: 1)),
     );
   }
@@ -841,7 +971,8 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
                 child: Text('thisGalleryHasANewVersion'.tr),
                 onPressed: () => toRoute(
                   Routes.details,
-                  arguments: DetailsPageArgument(galleryUrl: state.galleryDetails!.newVersionGalleryUrl!),
+                  arguments: DetailsPageArgument(
+                      galleryUrl: state.galleryDetails!.newVersionGalleryUrl!),
                   offAllBefore: false,
                   preventDuplicates: false,
                 ),
@@ -854,15 +985,38 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
   }
 
   Widget buildActions(BuildContext context) {
+    final bool appleStyle = ThemeConfig.isApple;
     return SliverToBoxAdapter(
       child: Container(
-        height: UIConfig.detailsPageActionsHeight,
-        margin: const EdgeInsets.only(top: 20, bottom: 16, left: UIConfig.detailPagePadding, right: UIConfig.detailPagePadding),
+        height: appleStyle ? 66 : UIConfig.detailsPageActionsHeight,
+        margin: EdgeInsets.only(
+            top: appleStyle ? 14 : 20,
+            bottom: appleStyle ? 14 : 16,
+            left: UIConfig.detailPagePadding,
+            right: UIConfig.detailPagePadding),
+        decoration: appleStyle
+            ? BoxDecoration(
+                color: Theme.of(context)
+                    .colorScheme
+                    .surfaceContainerHighest
+                    .withValues(alpha: 0.45),
+                borderRadius: BorderRadius.circular(10),
+                border: Border.all(
+                    color:
+                        Theme.of(context).dividerColor.withValues(alpha: 0.6),
+                    width: 0.5),
+              )
+            : null,
         child: LayoutBuilder(
           builder: (_, BoxConstraints constraints) => ListView(
             scrollDirection: Axis.horizontal,
-            physics: const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
-            itemExtent: max(UIConfig.detailsPageActionExtent, (constraints.maxWidth - UIConfig.detailPagePadding * 2) / 8),
+            physics: const BouncingScrollPhysics(
+                parent: AlwaysScrollableScrollPhysics()),
+            itemExtent: max(
+                appleStyle ? 72 : UIConfig.detailsPageActionExtent,
+                (constraints.maxWidth -
+                        (appleStyle ? 0 : UIConfig.detailPagePadding * 2)) /
+                    8),
             padding: EdgeInsets.zero,
             children: [
               _buildReadButton(context),
@@ -887,7 +1041,9 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
       global: false,
       init: logic,
       builder: (_) {
-        bool disabled = state.galleryDetails?.pageCount == null && state.gallery?.pageCount == null && state.galleryMetadata?.pageCount == null;
+        bool disabled = state.galleryDetails?.pageCount == null &&
+            state.gallery?.pageCount == null &&
+            state.galleryMetadata?.pageCount == null;
 
         return GetBuilder<DetailsPageLogic>(
           id: DetailsPageLogic.readButtonId,
@@ -900,19 +1056,25 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
               initialData: 0,
               builder: (_, AsyncSnapshot<int> snapshot) {
                 int readIndexRecord = snapshot.data ?? 0;
-                String text = (readIndexRecord == 0 ? 'read'.tr : 'P${readIndexRecord + 1}');
+                String text = (readIndexRecord == 0
+                    ? 'read'.tr
+                    : 'P${readIndexRecord + 1}');
 
                 return IconTextButton(
                   width: UIConfig.detailsPageActionExtent,
                   icon: Icon(
                     Icons.visibility,
-                    color: disabled ? UIConfig.detailsPageActionDisabledIconColor(context) : UIConfig.detailsPageActionIconColor(context),
+                    color: disabled
+                        ? UIConfig.detailsPageActionDisabledIconColor(context)
+                        : UIConfig.detailsPageActionIconColor(context),
                   ),
                   text: Text(
                     text,
                     style: TextStyle(
                       fontSize: UIConfig.detailsPageActionTextSize,
-                      color: disabled ? UIConfig.detailsPageActionDisabledIconColor(context) : UIConfig.detailsPageActionTextColor(context),
+                      color: disabled
+                          ? UIConfig.detailsPageActionDisabledIconColor(context)
+                          : UIConfig.detailsPageActionTextColor(context),
                       height: 1,
                     ),
                   ),
@@ -932,32 +1094,43 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
       global: false,
       init: logic,
       builder: (_) {
-        bool disabled = state.galleryDetails?.pageCount == null && state.gallery?.pageCount == null;
+        bool disabled = state.galleryDetails?.pageCount == null &&
+            state.gallery?.pageCount == null;
 
         return GetBuilder<GalleryDownloadService>(
           id: '${galleryDownloadService.galleryDownloadProgressId}::${state.galleryUrl.gid}',
           builder: (_) {
-            GalleryDownloadProgress? downloadProgress = galleryDownloadService.galleryDownloadInfos[state.galleryUrl.gid]?.downloadProgress;
+            GalleryDownloadProgress? downloadProgress = galleryDownloadService
+                .galleryDownloadInfos[state.galleryUrl.gid]?.downloadProgress;
 
             String text = downloadProgress == null
                 ? 'download'.tr
                 : downloadProgress.downloadStatus == DownloadStatus.paused
                     ? 'resume'.tr
-                    : downloadProgress.downloadStatus == DownloadStatus.downloading
+                    : downloadProgress.downloadStatus ==
+                            DownloadStatus.downloading
                         ? 'pause'.tr
                         : state.galleryDetails?.newVersionGalleryUrl == null
                             ? 'finished'.tr
                             : 'update'.tr;
 
             Icon icon = downloadProgress == null
-                ? Icon(Icons.download, color: disabled ? UIConfig.detailsPageActionDisabledIconColor(context) : UIConfig.detailsPageActionIconColor(context))
+                ? Icon(Icons.download,
+                    color: disabled
+                        ? UIConfig.detailsPageActionDisabledIconColor(context)
+                        : UIConfig.detailsPageActionIconColor(context))
                 : downloadProgress.downloadStatus == DownloadStatus.paused
-                    ? Icon(Icons.play_circle_outline, color: UIConfig.resumePauseButtonColor(context))
-                    : downloadProgress.downloadStatus == DownloadStatus.downloading
-                        ? Icon(Icons.pause_circle_outline, color: UIConfig.resumePauseButtonColor(context))
+                    ? Icon(Icons.play_circle_outline,
+                        color: UIConfig.resumePauseButtonColor(context))
+                    : downloadProgress.downloadStatus ==
+                            DownloadStatus.downloading
+                        ? Icon(Icons.pause_circle_outline,
+                            color: UIConfig.resumePauseButtonColor(context))
                         : state.galleryDetails?.newVersionGalleryUrl == null
-                            ? Icon(Icons.done, color: UIConfig.resumePauseButtonColor(context))
-                            : Icon(Icons.auto_awesome, color: UIConfig.alertColor(context));
+                            ? Icon(Icons.done,
+                                color: UIConfig.resumePauseButtonColor(context))
+                            : Icon(Icons.auto_awesome,
+                                color: UIConfig.alertColor(context));
 
             return IconTextButton(
               width: UIConfig.detailsPageActionExtent,
@@ -966,7 +1139,9 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
                 text,
                 style: TextStyle(
                   fontSize: UIConfig.detailsPageActionTextSize,
-                  color: disabled ? UIConfig.detailsPageActionDisabledIconColor(context) : UIConfig.detailsPageActionTextColor(context),
+                  color: disabled
+                      ? UIConfig.detailsPageActionDisabledIconColor(context)
+                      : UIConfig.detailsPageActionTextColor(context),
                   height: 1,
                 ),
               ),
@@ -987,8 +1162,10 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
       init: logic,
       builder: (_) {
         bool disabled = state.galleryDetails == null && state.gallery == null;
-        int? favoriteTagIndex = state.galleryDetails?.favoriteTagIndex ?? state.gallery?.favoriteTagIndex;
-        String? favoriteTagName = state.galleryDetails?.favoriteTagName ?? state.gallery?.favoriteTagName;
+        int? favoriteTagIndex = state.galleryDetails?.favoriteTagIndex ??
+            state.gallery?.favoriteTagIndex;
+        String? favoriteTagName = state.galleryDetails?.favoriteTagName ??
+            state.gallery?.favoriteTagName;
 
         return LoadingStateIndicator(
           loadingState: state.favoriteState,
@@ -1008,13 +1185,24 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
               overflow: TextOverflow.ellipsis,
               style: TextStyle(
                 fontSize: UIConfig.detailsPageActionTextSize,
-                color: disabled ? UIConfig.detailsPageActionDisabledIconColor(context) : UIConfig.detailsPageActionTextColor(context),
+                color: disabled
+                    ? UIConfig.detailsPageActionDisabledIconColor(context)
+                    : UIConfig.detailsPageActionTextColor(context),
                 height: 1,
               ),
             ),
-            onPressed: disabled ? null : () => logic.handleTapFavorite(useDefault: preferenceSetting.enableDefaultFavorite.isTrue),
-            onLongPress: disabled || preferenceSetting.enableDefaultFavorite.isFalse ? null : () => logic.handleTapFavorite(useDefault: false),
-            onSecondaryTap: disabled || preferenceSetting.enableDefaultFavorite.isFalse ? null : () => logic.handleTapFavorite(useDefault: false),
+            onPressed: disabled
+                ? null
+                : () => logic.handleTapFavorite(
+                    useDefault: preferenceSetting.enableDefaultFavorite.isTrue),
+            onLongPress:
+                disabled || preferenceSetting.enableDefaultFavorite.isFalse
+                    ? null
+                    : () => logic.handleTapFavorite(useDefault: false),
+            onSecondaryTap:
+                disabled || preferenceSetting.enableDefaultFavorite.isFalse
+                    ? null
+                    : () => logic.handleTapFavorite(useDefault: false),
           ),
           errorWidgetSameWithIdle: true,
         );
@@ -1029,8 +1217,11 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
       init: logic,
       builder: (_) {
         bool disabled = state.galleryDetails == null && state.gallery == null;
-        bool hasRated = state.galleryDetails?.hasRated ?? state.gallery?.hasRated ?? false;
-        double? rating = state.galleryDetails?.rating ?? state.gallery?.rating ?? state.galleryMetadata?.rating;
+        bool hasRated =
+            state.galleryDetails?.hasRated ?? state.gallery?.hasRated ?? false;
+        double? rating = state.galleryDetails?.rating ??
+            state.gallery?.rating ??
+            state.galleryMetadata?.rating;
 
         return LoadingStateIndicator(
           loadingState: state.ratingState,
@@ -1048,7 +1239,9 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
               hasRated ? rating!.toString() : 'rating'.tr,
               style: TextStyle(
                 fontSize: UIConfig.detailsPageActionTextSize,
-                color: disabled ? UIConfig.detailsPageActionDisabledIconColor(context) : UIConfig.detailsPageActionTextColor(context),
+                color: disabled
+                    ? UIConfig.detailsPageActionDisabledIconColor(context)
+                    : UIConfig.detailsPageActionTextColor(context),
                 height: 1,
               ),
             ),
@@ -1071,19 +1264,28 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
         return GetBuilder<ArchiveDownloadService>(
           id: '${ArchiveDownloadService.archiveStatusId}::${state.galleryUrl.gid}',
           builder: (_) {
-            ArchiveStatus? archiveStatus = archiveDownloadService.archiveDownloadInfos[state.galleryUrl.gid]?.archiveStatus;
+            ArchiveStatus? archiveStatus = archiveDownloadService
+                .archiveDownloadInfos[state.galleryUrl.gid]?.archiveStatus;
 
-            String text = archiveStatus == null ? 'archive'.tr : archiveStatus.name.tr;
+            String text =
+                archiveStatus == null ? 'archive'.tr : archiveStatus.name.tr;
 
             Icon icon = archiveStatus == null
-                ? Icon(Icons.archive, color: disabled ? UIConfig.detailsPageActionDisabledIconColor(context) : UIConfig.detailsPageActionIconColor(context))
+                ? Icon(Icons.archive,
+                    color: disabled
+                        ? UIConfig.detailsPageActionDisabledIconColor(context)
+                        : UIConfig.detailsPageActionIconColor(context))
                 : archiveStatus == ArchiveStatus.needReUnlock
                     ? Icon(Icons.lock_open, color: UIConfig.alertColor(context))
                     : archiveStatus == ArchiveStatus.paused
-                        ? Icon(Icons.play_circle_outline, color: UIConfig.resumePauseButtonColor(context))
+                        ? Icon(Icons.play_circle_outline,
+                            color: UIConfig.resumePauseButtonColor(context))
                         : archiveStatus == ArchiveStatus.completed
-                            ? Icon(Icons.done, color: UIConfig.resumePauseButtonColor(context))
-                            : Icon(Icons.pause_circle_outline, color: UIConfig.resumePauseButtonColor(context));
+                            ? Icon(Icons.done,
+                                color: UIConfig.resumePauseButtonColor(context))
+                            : Icon(Icons.pause_circle_outline,
+                                color:
+                                    UIConfig.resumePauseButtonColor(context));
 
             return IconTextButton(
               width: UIConfig.detailsPageActionExtent,
@@ -1092,11 +1294,14 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
                 text,
                 style: TextStyle(
                   fontSize: UIConfig.detailsPageActionTextSize,
-                  color: disabled ? UIConfig.detailsPageActionDisabledIconColor(context) : UIConfig.detailsPageActionTextColor(context),
+                  color: disabled
+                      ? UIConfig.detailsPageActionDisabledIconColor(context)
+                      : UIConfig.detailsPageActionTextColor(context),
                   height: 1,
                 ),
               ),
-              onPressed: disabled ? null : () => logic.handleTapArchive(context),
+              onPressed:
+                  disabled ? null : () => logic.handleTapArchive(context),
               onLongPress: () => toRoute(Routes.download),
               onSecondaryTap: () => toRoute(Routes.download),
             );
@@ -1116,13 +1321,17 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
 
         return IconTextButton(
           width: UIConfig.detailsPageActionExtent,
-          icon:
-              Icon(Icons.cloud_download, color: disabled ? UIConfig.detailsPageActionDisabledIconColor(context) : UIConfig.detailsPageActionIconColor(context)),
+          icon: Icon(Icons.cloud_download,
+              color: disabled
+                  ? UIConfig.detailsPageActionDisabledIconColor(context)
+                  : UIConfig.detailsPageActionIconColor(context)),
           text: Text(
             'H@H',
             style: TextStyle(
               fontSize: UIConfig.detailsPageActionTextSize,
-              color: disabled ? UIConfig.detailsPageActionDisabledIconColor(context) : UIConfig.detailsPageActionTextColor(context),
+              color: disabled
+                  ? UIConfig.detailsPageActionDisabledIconColor(context)
+                  : UIConfig.detailsPageActionTextColor(context),
               height: 1,
             ),
           ),
@@ -1138,16 +1347,23 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
       global: false,
       init: logic,
       builder: (_) {
-        bool disabled = state.gallery == null && state.galleryDetails == null && state.galleryMetadata == null;
+        bool disabled = state.gallery == null &&
+            state.galleryDetails == null &&
+            state.galleryMetadata == null;
 
         return IconTextButton(
           width: UIConfig.detailsPageActionExtent,
-          icon: Icon(Icons.saved_search, color: disabled ? UIConfig.detailsPageActionDisabledIconColor(context) : UIConfig.detailsPageActionIconColor(context)),
+          icon: Icon(Icons.saved_search,
+              color: disabled
+                  ? UIConfig.detailsPageActionDisabledIconColor(context)
+                  : UIConfig.detailsPageActionIconColor(context)),
           text: Text(
             'similar'.tr,
             style: TextStyle(
               fontSize: UIConfig.detailsPageActionTextSize,
-              color: disabled ? UIConfig.detailsPageActionDisabledIconColor(context) : UIConfig.detailsPageActionTextColor(context),
+              color: disabled
+                  ? UIConfig.detailsPageActionDisabledIconColor(context)
+                  : UIConfig.detailsPageActionTextColor(context),
               height: 1,
             ),
           ),
@@ -1163,22 +1379,31 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
       global: false,
       init: logic,
       builder: (_) {
-        bool disabled = state.galleryDetails == null || state.galleryDetails!.torrentCount == '0';
+        bool disabled = state.galleryDetails == null ||
+            state.galleryDetails!.torrentCount == '0';
 
-        String text = '${'torrent'.tr}(${state.galleryDetails?.torrentCount ?? '.'})';
+        String text =
+            '${'torrent'.tr}(${state.galleryDetails?.torrentCount ?? '.'})';
 
         return IconTextButton(
           width: UIConfig.detailsPageActionExtent,
-          icon: Icon(Icons.file_present, color: disabled ? UIConfig.detailsPageActionDisabledIconColor(context) : UIConfig.detailsPageActionIconColor(context)),
+          icon: Icon(Icons.file_present,
+              color: disabled
+                  ? UIConfig.detailsPageActionDisabledIconColor(context)
+                  : UIConfig.detailsPageActionIconColor(context)),
           text: Text(
             text,
             style: TextStyle(
               fontSize: UIConfig.detailsPageActionTextSize,
-              color: disabled ? UIConfig.detailsPageActionDisabledIconColor(context) : UIConfig.detailsPageActionTextColor(context),
+              color: disabled
+                  ? UIConfig.detailsPageActionDisabledIconColor(context)
+                  : UIConfig.detailsPageActionTextColor(context),
               height: 1,
             ),
           ),
-          onPressed: disabled || state.galleryDetails!.torrentCount == '0' ? null : logic.handleTapTorrent,
+          onPressed: disabled || state.galleryDetails!.torrentCount == '0'
+              ? null
+              : logic.handleTapTorrent,
         );
       },
     );
@@ -1194,16 +1419,22 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
 
         return IconTextButton(
           width: UIConfig.detailsPageActionExtent,
-          icon: Icon(Icons.analytics, color: disabled ? UIConfig.detailsPageActionDisabledIconColor(context) : UIConfig.detailsPageActionIconColor(context)),
+          icon: Icon(Icons.analytics,
+              color: disabled
+                  ? UIConfig.detailsPageActionDisabledIconColor(context)
+                  : UIConfig.detailsPageActionIconColor(context)),
           text: Text(
             'statistic'.tr,
             style: TextStyle(
               fontSize: UIConfig.detailsPageActionTextSize,
-              color: disabled ? UIConfig.detailsPageActionDisabledIconColor(context) : UIConfig.detailsPageActionTextColor(context),
+              color: disabled
+                  ? UIConfig.detailsPageActionDisabledIconColor(context)
+                  : UIConfig.detailsPageActionTextColor(context),
               height: 1,
             ),
           ),
-          onPressed: state.galleryDetails == null ? null : logic.handleTapStatistic,
+          onPressed:
+              state.galleryDetails == null ? null : logic.handleTapStatistic,
         );
       },
     );
@@ -1238,7 +1469,10 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
           return Container(
             height: UIConfig.detailsPageCopyRightRemovedHintHeight,
             alignment: Alignment.center,
-            child: Text(state.copyRighter!, style: const TextStyle(fontSize: UIConfig.detailsPageCopyRightRemovedHintTextSize)),
+            child: Text(state.copyRighter!,
+                style: const TextStyle(
+                    fontSize:
+                        UIConfig.detailsPageCopyRightRemovedHintTextSize)),
           ).fadeIn().marginSymmetric(horizontal: UIConfig.detailPagePadding);
         },
       ),
@@ -1287,7 +1521,9 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
         tagData: TagData(
           namespace: 'rows',
           key: category,
-          tagName: preferenceSetting.enableTagZHTranslation.isTrue ? EHNamespace.findNameSpaceFromDescOrAbbr(category)?.chineseDesc : null,
+          tagName: preferenceSetting.enableTagZHTranslation.isTrue
+              ? EHNamespace.findNameSpaceFromDescOrAbbr(category)?.chineseDesc
+              : null,
         ),
       ),
       addNameSpaceColor: true,
@@ -1299,7 +1535,9 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
         .map(
           (tag) => EHTag(
             tag: tag,
-            onTap: (tag) => newSearch(keyword: '${tag.tagData.namespace}:"${tag.tagData.key}\$"', forceNewRoute: true),
+            onTap: (tag) => newSearch(
+                keyword: '${tag.tagData.namespace}:"${tag.tagData.key}\$"',
+                forceNewRoute: true),
             onSecondaryTap: logic.showTagDialog,
             onLongPress: logic.showTagDialog,
             showTagStatus: preferenceSetting.showGalleryTagVoteStatus.isTrue,
@@ -1319,7 +1557,8 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
             return const SizedBox();
           }
 
-          bool disableButtons = state.galleryDetails!.comments.any((comment) => comment.fromMe);
+          bool disableButtons =
+              state.galleryDetails!.comments.any((comment) => comment.fromMe);
 
           return Column(
             children: [
@@ -1328,14 +1567,18 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
                 child: Align(
                   alignment: Alignment.centerRight,
                   child: TextButton(
-                    onPressed: () => toRoute(Routes.comment, arguments: state.galleryDetails!.comments),
-                    child: Text(state.galleryDetails!.comments.isEmpty ? 'noComments'.tr : 'allComments'.tr),
+                    onPressed: () => toRoute(Routes.comment,
+                        arguments: state.galleryDetails!.comments),
+                    child: Text(state.galleryDetails!.comments.isEmpty
+                        ? 'noComments'.tr
+                        : 'allComments'.tr),
                   ),
                 ),
               ),
               if (state.galleryDetails!.comments.isNotEmpty)
                 GestureDetector(
-                  onTap: () => toRoute(Routes.comment, arguments: state.galleryDetails!.comments),
+                  onTap: () => toRoute(Routes.comment,
+                      arguments: state.galleryDetails!.comments),
                   child: SizedBox(
                     height: UIConfig.detailsPageCommentsRegionHeight,
                     child: ListView.builder(
@@ -1343,13 +1586,20 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
                       padding: EdgeInsets.zero,
                       itemExtent: UIConfig.detailsPageCommentsWidth,
                       itemCount: state.galleryDetails!.comments.length,
-                      itemBuilder: (BuildContext context, int index) => EHComment(
-                        key: ValueKey(state.galleryDetails!.comments[index].score),
+                      itemBuilder: (BuildContext context, int index) =>
+                          EHComment(
+                        key: ValueKey(
+                            state.galleryDetails!.comments[index].score),
                         comment: state.galleryDetails!.comments[index],
                         inDetailPage: true,
                         disableButtons: disableButtons,
-                        onVoted: (bool isVotingUp, String score) => logic.onCommentVoted(state.galleryDetails!.comments[index], isVotingUp, score),
-                        onBlockUser: () => logic.blockUser(state.galleryDetails!.comments[index]),
+                        onVoted: (bool isVotingUp, String score) =>
+                            logic.onCommentVoted(
+                                state.galleryDetails!.comments[index],
+                                isVotingUp,
+                                score),
+                        onBlockUser: () => logic
+                            .blockUser(state.galleryDetails!.comments[index]),
                       ),
                     ).enableMouseDrag(withScrollBar: false),
                   ),
@@ -1371,19 +1621,26 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
         global: false,
         init: logic,
         builder: (_) => SliverPadding(
-          padding: const EdgeInsets.only(top: 36, left: UIConfig.detailPagePadding, right: UIConfig.detailPagePadding),
+          padding: const EdgeInsets.only(
+              top: 36,
+              left: UIConfig.detailPagePadding,
+              right: UIConfig.detailPagePadding),
           sliver: state.galleryDetails == null
               ? const SliverToBoxAdapter()
               : SliverGrid(
                   delegate: SliverChildBuilderDelegate(
                     (context, index) {
-                      if (index == state.galleryDetails!.thumbnails.length - 1 && state.loadingThumbnailsState == LoadingState.idle) {
+                      if (index ==
+                              state.galleryDetails!.thumbnails.length - 1 &&
+                          state.loadingThumbnailsState == LoadingState.idle) {
                         SchedulerBinding.instance.addPostFrameCallback((_) {
                           logic.loadMoreThumbnails();
                         });
                       }
 
-                      GalleryImage? downloadedImage = galleryDownloadService.galleryDownloadInfos[state.galleryUrl.gid]?.images[index];
+                      GalleryImage? downloadedImage = galleryDownloadService
+                          .galleryDownloadInfos[state.galleryUrl.gid]
+                          ?.images[index];
 
                       return Column(
                         children: [
@@ -1392,43 +1649,58 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
                               child: GestureDetector(
                                 onTap: () => logic.goToReadPage(index),
                                 child: LayoutBuilder(
-                                  builder: (_, constraints) => downloadedImage?.downloadStatus == DownloadStatus.downloaded
+                                  builder: (_, constraints) => downloadedImage
+                                              ?.downloadStatus ==
+                                          DownloadStatus.downloaded
                                       ? EHImage(
                                           galleryImage: downloadedImage!,
-                                          containerHeight: constraints.maxHeight,
+                                          containerHeight:
+                                              constraints.maxHeight,
                                           containerWidth: constraints.maxWidth,
-                                          borderRadius: BorderRadius.circular(8),
+                                          borderRadius:
+                                              BorderRadius.circular(8),
                                           maxBytes: 128 * 1024,
                                         )
                                       : EHThumbnail(
-                                          thumbnail: state.galleryDetails!.thumbnails[index],
-                                          containerHeight: constraints.maxHeight,
+                                          thumbnail: state.galleryDetails!
+                                              .thumbnails[index],
+                                          containerHeight:
+                                              constraints.maxHeight,
                                           containerWidth: constraints.maxWidth,
-                                          borderRadius: BorderRadius.circular(8),
+                                          borderRadius:
+                                              BorderRadius.circular(8),
                                         ),
                                 ),
                               ),
                             ),
                           ),
                           const SizedBox(height: 3),
-                          Text((index + 1).toString(), style: TextStyle(color: UIConfig.detailsPageThumbnailIndexColor(context))),
+                          Text((index + 1).toString(),
+                              style: TextStyle(
+                                  color:
+                                      UIConfig.detailsPageThumbnailIndexColor(
+                                          context))),
                         ],
                       );
                     },
                     childCount: state.galleryDetails?.thumbnails.length ?? 0,
                   ),
-                  gridDelegate: styleSetting.crossAxisCountInDetailPage.value == null
+                  gridDelegate: styleSetting.crossAxisCountInDetailPage.value ==
+                          null
                       ? const SliverGridDelegateWithMaxCrossAxisExtent(
                           mainAxisExtent: UIConfig.detailsPageThumbnailHeight,
-                          maxCrossAxisExtent: UIConfig.detailsPageThumbnailWidth,
+                          maxCrossAxisExtent:
+                              UIConfig.detailsPageThumbnailWidth,
                           mainAxisSpacing: 20,
                           crossAxisSpacing: 5,
                         )
                       : SliverGridDelegateWithFixedCrossAxisCount(
-                          crossAxisCount: styleSetting.crossAxisCountInDetailPage.value!,
+                          crossAxisCount:
+                              styleSetting.crossAxisCountInDetailPage.value!,
                           mainAxisSpacing: 20,
                           crossAxisSpacing: 5,
-                          childAspectRatio: UIConfig.detailsPageGridViewCardAspectRatio,
+                          childAspectRatio:
+                              UIConfig.detailsPageGridViewCardAspectRatio,
                         ),
                 ),
         ),

--- a/lib/src/pages/download/grid/mixin/grid_download_page_mixin.dart
+++ b/lib/src/pages/download/grid/mixin/grid_download_page_mixin.dart
@@ -39,7 +39,11 @@ mixin GridBasePage on StatelessWidget implements Scroll2TopPageMixin {
       appBar: buildAppBar(context),
       body: buildBody(context),
       floatingActionButton: buildFloatingActionButton(),
-      bottomNavigationBar: buildGridBottomAppBar(context),
+      floatingActionButtonLocation: GlassAwareFloatingActionButtonLocation(UIConfig.liquidGlassNavBarRaise(context)),
+      bottomNavigationBar: Padding(
+        padding: EdgeInsets.only(bottom: UIConfig.liquidGlassNavContentInset(context)),
+        child: buildGridBottomAppBar(context),
+      ),
     );
   }
 
@@ -81,7 +85,7 @@ mixin GridBasePage on StatelessWidget implements Scroll2TopPageMixin {
               () => DraggableGridViewBuilder(
                 key: PageStorageKey(state.currentGroup),
                 controller: state.scrollController,
-                padding: const EdgeInsets.only(left: 12, right: 16, bottom: 24),
+                padding: EdgeInsets.only(left: 12, right: 16, bottom: 24 + UIConfig.liquidGlassNavContentInset(context)),
                 children: getChildren(context),
                 dragFeedback: (List<DraggableGridItem> list, int index) {
                   return SizedBox(

--- a/lib/src/pages/download/list/archive/archive_list_download_page.dart
+++ b/lib/src/pages/download/list/archive/archive_list_download_page.dart
@@ -48,7 +48,11 @@ class ArchiveListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
       appBar: buildAppBar(context),
       body: buildBody(context),
       floatingActionButton: buildFloatingActionButton(),
-      bottomNavigationBar: buildBottomAppBar(),
+      floatingActionButtonLocation: GlassAwareFloatingActionButtonLocation(UIConfig.liquidGlassNavBarRaise(context)),
+      bottomNavigationBar: Padding(
+        padding: EdgeInsets.only(bottom: UIConfig.liquidGlassNavContentInset(context)),
+        child: buildBottomAppBar(),
+      ),
     );
   }
 
@@ -147,6 +151,7 @@ class ArchiveListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
                     maxGalleryNum4Animation: performanceSetting.maxGalleryNum4Animation.value,
                     scrollController: state.scrollController,
                     controller: state.groupedListController,
+                    bottomPadding: UIConfig.liquidGlassNavContentInset(context),
                     groups: Map.fromEntries(archiveDownloadService.allGroups.map((e) => MapEntry(e, state.displayGroups.contains(e)))),
                     elements: archiveDownloadService.archives,
                     elementGroup: (ArchiveDownloadedData archive) => archiveDownloadService.archiveDownloadInfos[archive.gid]!.group,

--- a/lib/src/pages/download/list/archive/archive_list_download_page.dart
+++ b/lib/src/pages/download/list/archive/archive_list_download_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:get/get.dart';
+import 'package:jhentai/src/config/theme_config.dart';
 import 'package:jhentai/src/config/ui_config.dart';
 import 'package:jhentai/src/database/database.dart';
 import 'package:jhentai/src/mixin/scroll_to_top_page_mixin.dart';
@@ -30,11 +31,18 @@ import '../../mixin/basic/multi_select/multi_select_download_page_mixin.dart';
 import 'archive_list_download_page_logic.dart';
 import 'archive_list_download_page_state.dart';
 
-class ArchiveListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, MultiSelectDownloadPageMixin, ArchiveDownloadPageMixin {
+class ArchiveListDownloadPage extends StatelessWidget
+    with
+        Scroll2TopPageMixin,
+        MultiSelectDownloadPageMixin,
+        ArchiveDownloadPageMixin {
   ArchiveListDownloadPage({Key? key}) : super(key: key);
 
-  final ArchiveListDownloadPageLogic logic = Get.put<ArchiveListDownloadPageLogic>(ArchiveListDownloadPageLogic(), permanent: true);
-  final ArchiveListDownloadPageState state = Get.find<ArchiveListDownloadPageLogic>().state;
+  final ArchiveListDownloadPageLogic logic =
+      Get.put<ArchiveListDownloadPageLogic>(ArchiveListDownloadPageLogic(),
+          permanent: true);
+  final ArchiveListDownloadPageState state =
+      Get.find<ArchiveListDownloadPageLogic>().state;
 
   @override
   ArchiveDownloadPageLogicMixin get archiveDownloadPageLogic => logic;
@@ -48,9 +56,11 @@ class ArchiveListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
       appBar: buildAppBar(context),
       body: buildBody(context),
       floatingActionButton: buildFloatingActionButton(),
-      floatingActionButtonLocation: GlassAwareFloatingActionButtonLocation(UIConfig.liquidGlassNavBarRaise(context)),
+      floatingActionButtonLocation: GlassAwareFloatingActionButtonLocation(
+          UIConfig.liquidGlassNavBarRaise(context)),
       bottomNavigationBar: Padding(
-        padding: EdgeInsets.only(bottom: UIConfig.liquidGlassNavContentInset(context)),
+        padding: EdgeInsets.only(
+            bottom: UIConfig.liquidGlassNavContentInset(context)),
         child: buildBottomAppBar(),
       ),
     );
@@ -61,7 +71,9 @@ class ArchiveListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
       centerTitle: true,
       leading: styleSetting.isInV2Layout
           ? IconButton(
-              icon: isRouteAtTop(Routes.download) ? const Icon(Icons.arrow_back) : Icon(Icons.menu, size: 20),
+              icon: isRouteAtTop(Routes.download)
+                  ? const Icon(Icons.arrow_back)
+                  : Icon(Icons.menu, size: 20),
               onPressed: () {
                 if (isRouteAtTop(Routes.download)) {
                   backRoute(currentRoute: Routes.download);
@@ -72,7 +84,8 @@ class ArchiveListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
             )
           : null,
       titleSpacing: 0,
-      title: const DownloadPageSegmentControl(galleryType: DownloadPageGalleryType.archive),
+      title: const DownloadPageSegmentControl(
+          galleryType: DownloadPageGalleryType.archive),
       actions: [
         PopupMenuButton(
           itemBuilder: (context) {
@@ -81,42 +94,64 @@ class ArchiveListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
                 value: 0,
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
-                  children: [const Icon(Icons.grid_view), const SizedBox(width: 12), Text('switch2GridMode'.tr)],
+                  children: [
+                    const Icon(Icons.grid_view),
+                    const SizedBox(width: 12),
+                    Text('switch2GridMode'.tr)
+                  ],
                 ),
               ),
               PopupMenuItem(
                 value: 1,
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
-                  children: [const Icon(Icons.done_all), const SizedBox(width: 12), Text('multiSelect'.tr)],
+                  children: [
+                    const Icon(Icons.done_all),
+                    const SizedBox(width: 12),
+                    Text('multiSelect'.tr)
+                  ],
                 ),
               ),
               PopupMenuItem(
                 value: 2,
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
-                  children: [const Icon(Icons.play_arrow), const SizedBox(width: 12), Text('resumeAllTasks'.tr)],
+                  children: [
+                    const Icon(Icons.play_arrow),
+                    const SizedBox(width: 12),
+                    Text('resumeAllTasks'.tr)
+                  ],
                 ),
               ),
               PopupMenuItem(
                 value: 3,
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
-                  children: [const Icon(Icons.pause), const SizedBox(width: 12), Text('pauseAllTasks'.tr)],
+                  children: [
+                    const Icon(Icons.pause),
+                    const SizedBox(width: 12),
+                    Text('pauseAllTasks'.tr)
+                  ],
                 ),
               ),
               PopupMenuItem(
                 value: 4,
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
-                  children: [const Icon(Icons.search), const SizedBox(width: 12), Text('search'.tr)],
+                  children: [
+                    const Icon(Icons.search),
+                    const SizedBox(width: 12),
+                    Text('search'.tr)
+                  ],
                 ),
               ),
             ];
           },
           onSelected: (value) {
             if (value == 0) {
-              DownloadPageBodyTypeChangeNotification(bodyType: DownloadPageBodyType.grid).dispatch(context);
+              DownloadPageBodyTypeChangeNotification(
+                      bodyType: DownloadPageBodyType.grid)
+                  .dispatch(context);
             }
             if (value == 1) {
               logic.enterSelectMode();
@@ -148,17 +183,26 @@ class ArchiveListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
             builder: (_, __) => !state.displayGroupsCompleter.isCompleted
                 ? const Center()
                 : GroupedList<String, ArchiveDownloadedData>(
-                    maxGalleryNum4Animation: performanceSetting.maxGalleryNum4Animation.value,
+                    maxGalleryNum4Animation:
+                        performanceSetting.maxGalleryNum4Animation.value,
                     scrollController: state.scrollController,
                     controller: state.groupedListController,
                     bottomPadding: UIConfig.liquidGlassNavContentInset(context),
-                    groups: Map.fromEntries(archiveDownloadService.allGroups.map((e) => MapEntry(e, state.displayGroups.contains(e)))),
+                    groups: Map.fromEntries(archiveDownloadService.allGroups
+                        .map((e) =>
+                            MapEntry(e, state.displayGroups.contains(e)))),
                     elements: archiveDownloadService.archives,
-                    elementGroup: (ArchiveDownloadedData archive) => archiveDownloadService.archiveDownloadInfos[archive.gid]!.group,
-                    groupBuilder: (context, groupName, isOpen) => _groupBuilder(context, groupName, isOpen).marginAll(5),
-                    elementBuilder: (BuildContext context, String group, ArchiveDownloadedData archive, isOpen) => _itemBuilder(context, archive),
+                    elementGroup: (ArchiveDownloadedData archive) =>
+                        archiveDownloadService
+                            .archiveDownloadInfos[archive.gid]!.group,
+                    groupBuilder: (context, groupName, isOpen) =>
+                        _groupBuilder(context, groupName, isOpen).marginAll(5),
+                    elementBuilder: (BuildContext context, String group,
+                            ArchiveDownloadedData archive, isOpen) =>
+                        _itemBuilder(context, archive),
                     groupUniqueKey: (String group) => group,
-                    elementUniqueKey: (ArchiveDownloadedData archive) => archive.gid.toString(),
+                    elementUniqueKey: (ArchiveDownloadedData archive) =>
+                        archive.gid.toString(),
                   ),
           ),
         ),
@@ -174,13 +218,27 @@ class ArchiveListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
       child: Container(
         height: UIConfig.groupListHeight,
         decoration: BoxDecoration(
-          color: UIConfig.groupListColor(context),
-          boxShadow: [if (!Get.isDarkMode) UIConfig.groupListShadow(context)],
-          borderRadius: BorderRadius.circular(15),
+          color: ThemeConfig.isApple
+              ? Theme.of(context)
+                  .colorScheme
+                  .surfaceContainerHighest
+                  .withValues(alpha: 0.48)
+              : UIConfig.groupListColor(context),
+          boxShadow: ThemeConfig.isApple
+              ? null
+              : [if (!Get.isDarkMode) UIConfig.groupListShadow(context)],
+          borderRadius: BorderRadius.circular(ThemeConfig.isApple ? 8 : 15),
+          border: ThemeConfig.isApple
+              ? Border.all(
+                  color: Theme.of(context).dividerColor.withValues(alpha: 0.6),
+                  width: 0.5)
+              : null,
         ),
         child: Row(
           children: [
-            const SizedBox(width: UIConfig.downloadPageGroupHeaderWidth, child: Center(child: Icon(Icons.folder_open))),
+            const SizedBox(
+                width: UIConfig.downloadPageGroupHeaderWidth,
+                child: Center(child: Icon(Icons.folder_open))),
             Text(
               '$groupName${'(' + archiveDownloadService.archivesWithGroup(groupName).length.toString() + ')'}',
               maxLines: 1,
@@ -199,14 +257,20 @@ class ArchiveListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
       key: Key(archive.gid.toString()),
       endActionPane: _buildEndActionPane(context, archive),
       child: GestureDetector(
-        onSecondaryTapDown: (details) => logic.handleLongPressOrSecondaryTapItem(archive, context, position: details.globalPosition),
-        onLongPressStart: (details) => logic.handleLongPressOrSecondaryTapItem(archive, context, position: details.globalPosition),
-        child: _buildCard(context, archive).marginAll(5),
+        onSecondaryTapDown: (details) =>
+            logic.handleLongPressOrSecondaryTapItem(archive, context,
+                position: details.globalPosition),
+        onLongPressStart: (details) => logic.handleLongPressOrSecondaryTapItem(
+            archive, context,
+            position: details.globalPosition),
+        child:
+            _buildCard(context, archive).marginAll(ThemeConfig.isApple ? 0 : 5),
       ),
     );
   }
 
-  ActionPane _buildEndActionPane(BuildContext context, ArchiveDownloadedData archive) {
+  ActionPane _buildEndActionPane(
+      BuildContext context, ArchiveDownloadedData archive) {
     return ActionPane(
       motion: const DrawerMotion(),
       extentRatio: 0.3,
@@ -230,12 +294,28 @@ class ArchiveListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
     return GetBuilder<ArchiveListDownloadPageLogic>(
       id: '${logic.itemCardId}::${archive.gid}',
       builder: (_) => Container(
-        decoration: state.selectedGids.contains(archive.gid)
+        decoration: ThemeConfig.isApple
             ? BoxDecoration(
-                color: UIConfig.downloadPageCardSelectedColor(context),
-                borderRadius: BorderRadius.circular(UIConfig.downloadPageCardBorderRadius),
+                color: state.selectedGids.contains(archive.gid)
+                    ? Theme.of(context)
+                        .colorScheme
+                        .primary
+                        .withValues(alpha: 0.16)
+                    : Colors.transparent,
+                border: Border(
+                    bottom: BorderSide(
+                        width: 0.5,
+                        color: Theme.of(context)
+                            .dividerColor
+                            .withValues(alpha: 0.7))),
               )
-            : null,
+            : state.selectedGids.contains(archive.gid)
+                ? BoxDecoration(
+                    color: UIConfig.downloadPageCardSelectedColor(context),
+                    borderRadius: BorderRadius.circular(
+                        UIConfig.downloadPageCardBorderRadius),
+                  )
+                : null,
         height: UIConfig.downloadPageCardHeight,
         child: Row(
           children: [
@@ -252,13 +332,15 @@ class ArchiveListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
       behavior: HitTestBehavior.opaque,
       onTap: () => toRoute(
         Routes.details,
-        arguments: DetailsPageArgument(galleryUrl: GalleryUrl.parse(archive.galleryUrl)),
+        arguments: DetailsPageArgument(
+            galleryUrl: GalleryUrl.parse(archive.galleryUrl)),
       ),
       child: EHImage(
         galleryImage: GalleryImage(url: archive.coverUrl),
         containerWidth: UIConfig.downloadPageCoverWidth,
         containerHeight: UIConfig.downloadPageCoverHeight,
-        borderRadius: BorderRadius.circular(UIConfig.downloadPageCardBorderRadius),
+        borderRadius: BorderRadius.circular(
+            ThemeConfig.isApple ? 0 : UIConfig.downloadPageCardBorderRadius),
         fit: BoxFit.fitWidth,
         maxBytes: 2 * 1024 * 1024,
       ),
@@ -284,7 +366,9 @@ class ArchiveListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
                   _buildInfoFooter(context, archive),
                 ],
               ),
-              if (state.selectedGids.contains(archive.gid)) const Positioned(child: Center(child: Icon(Icons.check_circle))),
+              if (state.selectedGids.contains(archive.gid))
+                const Positioned(
+                    child: Center(child: Icon(Icons.check_circle))),
             ],
           ),
         ),
@@ -301,7 +385,8 @@ class ArchiveListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
           archive.title,
           maxLines: 2,
           overflow: TextOverflow.ellipsis,
-          style: const TextStyle(fontSize: UIConfig.downloadPageCardTitleSize, height: 1.2),
+          style: const TextStyle(
+              fontSize: UIConfig.downloadPageCardTitleSize, height: 1.2),
         ),
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -310,11 +395,17 @@ class ArchiveListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
             if (archive.uploader != null)
               Text(
                 archive.uploader!,
-                style: TextStyle(fontSize: UIConfig.downloadPageCardTextSize, color: UIConfig.downloadPageCardTextColor(context)),
+                style: TextStyle(
+                    fontSize: UIConfig.downloadPageCardTextSize,
+                    color: UIConfig.downloadPageCardTextColor(context)),
               ),
             Text(
-              preferenceSetting.showUtcTime.isTrue ? archive.publishTime : DateUtil.transformUtc2LocalTimeString(archive.publishTime),
-              style: TextStyle(fontSize: UIConfig.downloadPageCardTextSize, color: UIConfig.downloadPageCardTextColor(context)),
+              preferenceSetting.showUtcTime.isTrue
+                  ? archive.publishTime
+                  : DateUtil.transformUtc2LocalTimeString(archive.publishTime),
+              style: TextStyle(
+                  fontSize: UIConfig.downloadPageCardTextSize,
+                  color: UIConfig.downloadPageCardTextColor(context)),
             ),
           ],
         ).marginOnly(top: 5),
@@ -337,8 +428,10 @@ class ArchiveListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
     );
   }
 
-  Widget _buildReUnlockButton(BuildContext context, ArchiveDownloadedData archive) {
-    ArchiveDownloadInfo archiveDownloadInfo = archiveDownloadService.archiveDownloadInfos[archive.gid]!;
+  Widget _buildReUnlockButton(
+      BuildContext context, ArchiveDownloadedData archive) {
+    ArchiveDownloadInfo archiveDownloadInfo =
+        archiveDownloadService.archiveDownloadInfos[archive.gid]!;
 
     return GetBuilder<ArchiveDownloadService>(
       id: '${ArchiveDownloadService.archiveStatusId}::${archive.gid}',
@@ -349,14 +442,17 @@ class ArchiveListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
 
         return GestureDetector(
           onTap: () => logic.handleReUnlockArchive(archive),
-          child: Icon(Icons.lock_open, size: 18, color: UIConfig.alertColor(context)),
+          child: Icon(Icons.lock_open,
+              size: 18, color: UIConfig.alertColor(context)),
         ).marginOnly(right: 8);
       },
     );
   }
 
-  Widget _buildParseFromBot(BuildContext context, ArchiveDownloadedData archive) {
-    ArchiveDownloadInfo archiveDownloadInfo = archiveDownloadService.archiveDownloadInfos[archive.gid]!;
+  Widget _buildParseFromBot(
+      BuildContext context, ArchiveDownloadedData archive) {
+    ArchiveDownloadInfo archiveDownloadInfo =
+        archiveDownloadService.archiveDownloadInfos[archive.gid]!;
     return GetBuilder<ArchiveListDownloadPageLogic>(
       global: false,
       init: logic,
@@ -398,16 +494,21 @@ class ArchiveListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
       ),
       child: Text(
         'original'.tr,
-        style: TextStyle(color: UIConfig.resumePauseButtonColor(context), fontWeight: FontWeight.bold, fontSize: 9),
+        style: TextStyle(
+            color: UIConfig.resumePauseButtonColor(context),
+            fontWeight: FontWeight.bold,
+            fontSize: 9),
       ),
     );
   }
 
-  Widget _buildSuperResolutionLabel(BuildContext context, ArchiveDownloadedData archive) {
+  Widget _buildSuperResolutionLabel(
+      BuildContext context, ArchiveDownloadedData archive) {
     return GetBuilder<srs.SuperResolutionService>(
       id: '${srs.SuperResolutionService.superResolutionId}::${archive.gid}',
       builder: (_) {
-        srs.SuperResolutionInfo? superResolutionInfo = superResolutionService.get(archive.gid, srs.SuperResolutionType.archive);
+        srs.SuperResolutionInfo? superResolutionInfo = superResolutionService
+            .get(archive.gid, srs.SuperResolutionType.archive);
 
         if (superResolutionInfo == null) {
           return const SizedBox();
@@ -417,20 +518,30 @@ class ArchiveListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
           margin: const EdgeInsets.symmetric(horizontal: 6),
           padding: const EdgeInsets.symmetric(horizontal: 4),
           decoration: BoxDecoration(
-            borderRadius: superResolutionInfo.status == srs.SuperResolutionStatus.success ? null : BorderRadius.circular(4),
+            borderRadius:
+                superResolutionInfo.status == srs.SuperResolutionStatus.success
+                    ? null
+                    : BorderRadius.circular(4),
             border: Border.all(color: UIConfig.resumePauseButtonColor(context)),
-            shape: superResolutionInfo.status == srs.SuperResolutionStatus.success ? BoxShape.circle : BoxShape.rectangle,
+            shape:
+                superResolutionInfo.status == srs.SuperResolutionStatus.success
+                    ? BoxShape.circle
+                    : BoxShape.rectangle,
           ),
           child: Text(
             superResolutionInfo.status == srs.SuperResolutionStatus.paused
                 ? 'AI'
-                : superResolutionInfo.status == srs.SuperResolutionStatus.success
+                : superResolutionInfo.status ==
+                        srs.SuperResolutionStatus.success
                     ? 'AI'
                     : 'AI(${superResolutionInfo.imageStatuses.fold<int>(0, (previousValue, element) => previousValue + (element == srs.SuperResolutionStatus.success ? 1 : 0))}/${superResolutionInfo.imageStatuses.length})',
             style: TextStyle(
               fontSize: 9,
               color: UIConfig.resumePauseButtonColor(context),
-              decoration: superResolutionInfo.status == srs.SuperResolutionStatus.paused ? TextDecoration.lineThrough : null,
+              decoration:
+                  superResolutionInfo.status == srs.SuperResolutionStatus.paused
+                      ? TextDecoration.lineThrough
+                      : null,
             ),
           ),
         );
@@ -439,7 +550,8 @@ class ArchiveListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
   }
 
   Widget _buildButton(BuildContext context, ArchiveDownloadedData archive) {
-    ArchiveDownloadInfo archiveDownloadInfo = archiveDownloadService.archiveDownloadInfos[archive.gid]!;
+    ArchiveDownloadInfo archiveDownloadInfo =
+        archiveDownloadService.archiveDownloadInfos[archive.gid]!;
 
     return GetBuilder<ArchiveDownloadService>(
       id: '${ArchiveDownloadService.archiveStatusId}::${archive.gid}',
@@ -463,7 +575,8 @@ class ArchiveListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
   }
 
   Widget _buildInfoFooter(BuildContext context, ArchiveDownloadedData archive) {
-    ArchiveDownloadInfo archiveDownloadInfo = archiveDownloadService.archiveDownloadInfos[archive.gid]!;
+    ArchiveDownloadInfo archiveDownloadInfo =
+        archiveDownloadService.archiveDownloadInfos[archive.gid]!;
 
     return GetBuilder<ArchiveDownloadService>(
       id: '${ArchiveDownloadService.archiveStatusId}::${archive.gid}',
@@ -473,39 +586,53 @@ class ArchiveListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
           children: [
             Row(
               children: [
-                if (archiveDownloadInfo.archiveStatus == ArchiveStatus.downloading)
+                if (archiveDownloadInfo.archiveStatus ==
+                    ArchiveStatus.downloading)
                   GetBuilder<ArchiveDownloadService>(
                     id: '${ArchiveDownloadService.archiveSpeedComputerId}::${archive.gid}::${archive.isOriginal}',
                     builder: (_) => Text(
                       archiveDownloadInfo.speedComputer.speed,
-                      style: TextStyle(fontSize: UIConfig.downloadPageCardTextSize, color: UIConfig.downloadPageCardTextColor(context)),
+                      style: TextStyle(
+                          fontSize: UIConfig.downloadPageCardTextSize,
+                          color: UIConfig.downloadPageCardTextColor(context)),
                     ),
                   ),
                 const Expanded(child: SizedBox()),
-                if (archiveDownloadInfo.archiveStatus.code <= ArchiveStatus.downloading.code)
+                if (archiveDownloadInfo.archiveStatus.code <=
+                    ArchiveStatus.downloading.code)
                   GetBuilder<ArchiveDownloadService>(
                     id: '${ArchiveDownloadService.archiveSpeedComputerId}::${archive.gid}::${archive.isOriginal}',
                     builder: (_) => Text(
                       '${byte2String(archiveDownloadInfo.speedComputer.downloadedBytes.toDouble())}/${byte2String(archiveDownloadInfo.size.toDouble())}',
-                      style: TextStyle(fontSize: UIConfig.downloadPageCardTextSize, color: UIConfig.downloadPageCardTextColor(context)),
+                      style: TextStyle(
+                          fontSize: UIConfig.downloadPageCardTextSize,
+                          color: UIConfig.downloadPageCardTextColor(context)),
                     ),
                   ),
-                if (archiveDownloadInfo.archiveStatus != ArchiveStatus.downloading)
+                if (archiveDownloadInfo.archiveStatus !=
+                    ArchiveStatus.downloading)
                   Text(
                     archiveDownloadInfo.archiveStatus.name.tr,
-                    style: TextStyle(fontSize: UIConfig.downloadPageCardTextSize, color: UIConfig.downloadPageCardTextColor(context), height: 1),
+                    style: TextStyle(
+                        fontSize: UIConfig.downloadPageCardTextSize,
+                        color: UIConfig.downloadPageCardTextColor(context),
+                        height: 1),
                   ).marginOnly(left: 8),
               ],
             ),
-            if (archiveDownloadInfo.archiveStatus.code <= ArchiveStatus.downloading.code)
+            if (archiveDownloadInfo.archiveStatus.code <=
+                ArchiveStatus.downloading.code)
               SizedBox(
                 height: UIConfig.downloadPageProgressIndicatorHeight,
                 child: GetBuilder<ArchiveDownloadService>(
                   id: '${ArchiveDownloadService.archiveSpeedComputerId}::${archive.gid}::${archive.isOriginal}',
                   builder: (_) => LinearProgressIndicator(
-                    value: archiveDownloadInfo.speedComputer.downloadedBytes / archiveDownloadInfo.size,
-                    color: archiveDownloadInfo.archiveStatus.code <= ArchiveStatus.paused.code
-                        ? UIConfig.downloadPageProgressPausedIndicatorColor(context)
+                    value: archiveDownloadInfo.speedComputer.downloadedBytes /
+                        archiveDownloadInfo.size,
+                    color: archiveDownloadInfo.archiveStatus.code <=
+                            ArchiveStatus.paused.code
+                        ? UIConfig.downloadPageProgressPausedIndicatorColor(
+                            context)
                         : UIConfig.downloadPageProgressIndicatorColor(context),
                   ),
                 ),

--- a/lib/src/pages/download/list/gallery/gallery_list_download_page.dart
+++ b/lib/src/pages/download/list/gallery/gallery_list_download_page.dart
@@ -55,7 +55,11 @@ class GalleryListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
       appBar: buildAppBar(context),
       body: buildBody(context),
       floatingActionButton: buildFloatingActionButton(),
-      bottomNavigationBar: buildBottomAppBar(),
+      floatingActionButtonLocation: GlassAwareFloatingActionButtonLocation(UIConfig.liquidGlassNavBarRaise(context)),
+      bottomNavigationBar: Padding(
+        padding: EdgeInsets.only(bottom: UIConfig.liquidGlassNavContentInset(context)),
+        child: buildBottomAppBar(),
+      ),
     );
   }
 
@@ -154,6 +158,7 @@ class GalleryListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
                     maxGalleryNum4Animation: performanceSetting.maxGalleryNum4Animation.value,
                     scrollController: state.scrollController,
                     controller: state.groupedListController,
+                    bottomPadding: UIConfig.liquidGlassNavContentInset(context),
                     groups: Map.fromEntries(logic.downloadService.allGroups.map((e) => MapEntry(e, state.displayGroups.contains(e)))),
                     elements: logic.downloadService.gallerys,
                     elementGroup: (GalleryDownloadedData gallery) => logic.downloadService.galleryDownloadInfos[gallery.gid]!.group,

--- a/lib/src/pages/download/list/gallery/gallery_list_download_page.dart
+++ b/lib/src/pages/download/list/gallery/gallery_list_download_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:get/get.dart';
+import 'package:jhentai/src/config/theme_config.dart';
 import 'package:jhentai/src/config/ui_config.dart';
 import 'package:jhentai/src/extension/widget_extension.dart';
 import 'package:jhentai/src/model/gallery_url.dart';
@@ -31,11 +32,18 @@ import '../../mixin/gallery/gallery_download_page_state_mixin.dart';
 import 'gallery_list_download_page_logic.dart';
 import 'gallery_list_download_page_state.dart';
 
-class GalleryListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, MultiSelectDownloadPageMixin, GalleryDownloadPageMixin {
+class GalleryListDownloadPage extends StatelessWidget
+    with
+        Scroll2TopPageMixin,
+        MultiSelectDownloadPageMixin,
+        GalleryDownloadPageMixin {
   GalleryListDownloadPage({Key? key}) : super(key: key);
 
-  final GalleryListDownloadPageLogic logic = Get.put<GalleryListDownloadPageLogic>(GalleryListDownloadPageLogic(), permanent: true);
-  final GalleryListDownloadPageState state = Get.find<GalleryListDownloadPageLogic>().state;
+  final GalleryListDownloadPageLogic logic =
+      Get.put<GalleryListDownloadPageLogic>(GalleryListDownloadPageLogic(),
+          permanent: true);
+  final GalleryListDownloadPageState state =
+      Get.find<GalleryListDownloadPageLogic>().state;
 
   @override
   MultiSelectDownloadPageLogicMixin get multiSelectDownloadPageLogic => logic;
@@ -55,9 +63,11 @@ class GalleryListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
       appBar: buildAppBar(context),
       body: buildBody(context),
       floatingActionButton: buildFloatingActionButton(),
-      floatingActionButtonLocation: GlassAwareFloatingActionButtonLocation(UIConfig.liquidGlassNavBarRaise(context)),
+      floatingActionButtonLocation: GlassAwareFloatingActionButtonLocation(
+          UIConfig.liquidGlassNavBarRaise(context)),
       bottomNavigationBar: Padding(
-        padding: EdgeInsets.only(bottom: UIConfig.liquidGlassNavContentInset(context)),
+        padding: EdgeInsets.only(
+            bottom: UIConfig.liquidGlassNavContentInset(context)),
         child: buildBottomAppBar(),
       ),
     );
@@ -68,7 +78,9 @@ class GalleryListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
       centerTitle: true,
       leading: styleSetting.isInV2Layout
           ? IconButton(
-              icon: isRouteAtTop(Routes.download) ? const Icon(Icons.arrow_back) : Icon(Icons.menu, size: 20),
+              icon: isRouteAtTop(Routes.download)
+                  ? const Icon(Icons.arrow_back)
+                  : Icon(Icons.menu, size: 20),
               onPressed: () {
                 if (isRouteAtTop(Routes.download)) {
                   backRoute(currentRoute: Routes.download);
@@ -79,7 +91,8 @@ class GalleryListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
             )
           : null,
       titleSpacing: 0,
-      title: const DownloadPageSegmentControl(galleryType: DownloadPageGalleryType.download),
+      title: const DownloadPageSegmentControl(
+          galleryType: DownloadPageGalleryType.download),
       actions: [
         PopupMenuButton(
           itemBuilder: (context) {
@@ -88,42 +101,64 @@ class GalleryListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
                 value: 0,
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
-                  children: [const Icon(Icons.grid_view), const SizedBox(width: 12), Text('switch2GridMode'.tr)],
+                  children: [
+                    const Icon(Icons.grid_view),
+                    const SizedBox(width: 12),
+                    Text('switch2GridMode'.tr)
+                  ],
                 ),
               ),
               PopupMenuItem(
                 value: 1,
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
-                  children: [const Icon(Icons.done_all), const SizedBox(width: 12), Text('multiSelect'.tr)],
+                  children: [
+                    const Icon(Icons.done_all),
+                    const SizedBox(width: 12),
+                    Text('multiSelect'.tr)
+                  ],
                 ),
               ),
               PopupMenuItem(
                 value: 2,
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
-                  children: [const Icon(Icons.play_arrow), const SizedBox(width: 12), Text('resumeAllTasks'.tr)],
+                  children: [
+                    const Icon(Icons.play_arrow),
+                    const SizedBox(width: 12),
+                    Text('resumeAllTasks'.tr)
+                  ],
                 ),
               ),
               PopupMenuItem(
                 value: 3,
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
-                  children: [const Icon(Icons.pause), const SizedBox(width: 12), Text('pauseAllTasks'.tr)],
+                  children: [
+                    const Icon(Icons.pause),
+                    const SizedBox(width: 12),
+                    Text('pauseAllTasks'.tr)
+                  ],
                 ),
               ),
               PopupMenuItem(
                 value: 4,
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
-                  children: [const Icon(Icons.search), const SizedBox(width: 12), Text('search'.tr)],
+                  children: [
+                    const Icon(Icons.search),
+                    const SizedBox(width: 12),
+                    Text('search'.tr)
+                  ],
                 ),
               ),
             ];
           },
           onSelected: (value) {
             if (value == 0) {
-              DownloadPageBodyTypeChangeNotification(bodyType: DownloadPageBodyType.grid).dispatch(context);
+              DownloadPageBodyTypeChangeNotification(
+                      bodyType: DownloadPageBodyType.grid)
+                  .dispatch(context);
             }
             if (value == 1) {
               logic.enterSelectMode();
@@ -155,17 +190,26 @@ class GalleryListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
             builder: (_, __) => !state.displayGroupsCompleter.isCompleted
                 ? const Center()
                 : GroupedList<String, GalleryDownloadedData>(
-                    maxGalleryNum4Animation: performanceSetting.maxGalleryNum4Animation.value,
+                    maxGalleryNum4Animation:
+                        performanceSetting.maxGalleryNum4Animation.value,
                     scrollController: state.scrollController,
                     controller: state.groupedListController,
                     bottomPadding: UIConfig.liquidGlassNavContentInset(context),
-                    groups: Map.fromEntries(logic.downloadService.allGroups.map((e) => MapEntry(e, state.displayGroups.contains(e)))),
+                    groups: Map.fromEntries(logic.downloadService.allGroups.map(
+                        (e) => MapEntry(e, state.displayGroups.contains(e)))),
                     elements: logic.downloadService.gallerys,
-                    elementGroup: (GalleryDownloadedData gallery) => logic.downloadService.galleryDownloadInfos[gallery.gid]!.group,
-                    groupBuilder: (context, groupName, isOpen) => _groupBuilder(context, groupName, isOpen).marginAll(5),
-                    elementBuilder: (BuildContext context, String group, GalleryDownloadedData gallery, isOpen) => _itemBuilder(context, gallery),
+                    elementGroup: (GalleryDownloadedData gallery) => logic
+                        .downloadService
+                        .galleryDownloadInfos[gallery.gid]!
+                        .group,
+                    groupBuilder: (context, groupName, isOpen) =>
+                        _groupBuilder(context, groupName, isOpen).marginAll(5),
+                    elementBuilder: (BuildContext context, String group,
+                            GalleryDownloadedData gallery, isOpen) =>
+                        _itemBuilder(context, gallery),
                     groupUniqueKey: (String group) => group,
-                    elementUniqueKey: (GalleryDownloadedData gallery) => gallery.gid.toString(),
+                    elementUniqueKey: (GalleryDownloadedData gallery) =>
+                        gallery.gid.toString(),
                   ),
           ),
         ),
@@ -181,13 +225,27 @@ class GalleryListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
       child: Container(
         height: UIConfig.groupListHeight,
         decoration: BoxDecoration(
-          color: UIConfig.groupListColor(context),
-          boxShadow: [if (!Get.isDarkMode) UIConfig.groupListShadow(context)],
-          borderRadius: BorderRadius.circular(15),
+          color: ThemeConfig.isApple
+              ? Theme.of(context)
+                  .colorScheme
+                  .surfaceContainerHighest
+                  .withValues(alpha: 0.48)
+              : UIConfig.groupListColor(context),
+          boxShadow: ThemeConfig.isApple
+              ? null
+              : [if (!Get.isDarkMode) UIConfig.groupListShadow(context)],
+          borderRadius: BorderRadius.circular(ThemeConfig.isApple ? 8 : 15),
+          border: ThemeConfig.isApple
+              ? Border.all(
+                  color: Theme.of(context).dividerColor.withValues(alpha: 0.6),
+                  width: 0.5)
+              : null,
         ),
         child: Row(
           children: [
-            const SizedBox(width: UIConfig.downloadPageGroupHeaderWidth, child: Center(child: Icon(Icons.folder_open))),
+            const SizedBox(
+                width: UIConfig.downloadPageGroupHeaderWidth,
+                child: Center(child: Icon(Icons.folder_open))),
             Text(
               '$groupName${'(' + logic.downloadService.gallerysWithGroup(groupName).length.toString() + ')'}',
               maxLines: 1,
@@ -206,14 +264,20 @@ class GalleryListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
       key: Key(gallery.gid.toString()),
       endActionPane: _buildEndActionPane(context, gallery),
       child: GestureDetector(
-        onSecondaryTapDown: (details) => logic.handleLongPressOrSecondaryTapItem(gallery, context, position: details.globalPosition),
-        onLongPressStart: (details) => logic.handleLongPressOrSecondaryTapItem(gallery, context, position: details.globalPosition),
-        child: _buildCard(context, gallery).marginAll(5),
+        onSecondaryTapDown: (details) =>
+            logic.handleLongPressOrSecondaryTapItem(gallery, context,
+                position: details.globalPosition),
+        onLongPressStart: (details) => logic.handleLongPressOrSecondaryTapItem(
+            gallery, context,
+            position: details.globalPosition),
+        child:
+            _buildCard(context, gallery).marginAll(ThemeConfig.isApple ? 0 : 5),
       ),
     );
   }
 
-  ActionPane _buildEndActionPane(BuildContext context, GalleryDownloadedData gallery) {
+  ActionPane _buildEndActionPane(
+      BuildContext context, GalleryDownloadedData gallery) {
     return ActionPane(
       motion: const DrawerMotion(),
       extentRatio: 0.4,
@@ -226,13 +290,15 @@ class GalleryListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
         SlidableAction(
           icon: Icons.sort,
           backgroundColor: UIConfig.downloadPageActionBackGroundColor(context),
-          onPressed: (BuildContext context) => logic.showPrioritySheet(gallery, context),
+          onPressed: (BuildContext context) =>
+              logic.showPrioritySheet(gallery, context),
         ),
         SlidableAction(
           icon: Icons.delete,
           foregroundColor: UIConfig.alertColor(context),
           backgroundColor: UIConfig.downloadPageActionBackGroundColor(context),
-          onPressed: (BuildContext context) => logic.handleRemoveItem(gallery, true, context),
+          onPressed: (BuildContext context) =>
+              logic.handleRemoveItem(gallery, true, context),
         )
       ],
     );
@@ -243,12 +309,28 @@ class GalleryListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
       id: '${logic.itemCardId}::${gallery.gid}',
       builder: (_) => Container(
         height: UIConfig.downloadPageCardHeight,
-        decoration: state.selectedGids.contains(gallery.gid)
+        decoration: ThemeConfig.isApple
             ? BoxDecoration(
-                color: UIConfig.downloadPageCardSelectedColor(context),
-                borderRadius: BorderRadius.circular(UIConfig.downloadPageCardBorderRadius),
+                color: state.selectedGids.contains(gallery.gid)
+                    ? Theme.of(context)
+                        .colorScheme
+                        .primary
+                        .withValues(alpha: 0.16)
+                    : Colors.transparent,
+                border: Border(
+                    bottom: BorderSide(
+                        width: 0.5,
+                        color: Theme.of(context)
+                            .dividerColor
+                            .withValues(alpha: 0.7))),
               )
-            : null,
+            : state.selectedGids.contains(gallery.gid)
+                ? BoxDecoration(
+                    color: UIConfig.downloadPageCardSelectedColor(context),
+                    borderRadius: BorderRadius.circular(
+                        UIConfig.downloadPageCardBorderRadius),
+                  )
+                : null,
         child: Row(
           children: [
             _buildCover(context, gallery),
@@ -264,12 +346,14 @@ class GalleryListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
       behavior: HitTestBehavior.opaque,
       onTap: () => toRoute(
         Routes.details,
-        arguments: DetailsPageArgument(galleryUrl: GalleryUrl.parse(gallery.galleryUrl)),
+        arguments: DetailsPageArgument(
+            galleryUrl: GalleryUrl.parse(gallery.galleryUrl)),
       ),
       child: GetBuilder<GalleryDownloadService>(
         id: '${logic.downloadService.downloadImageUrlId}::${gallery.gid}::0',
         builder: (_) {
-          GalleryImage? image = logic.downloadService.galleryDownloadInfos[gallery.gid]?.images[0];
+          GalleryImage? image = logic
+              .downloadService.galleryDownloadInfos[gallery.gid]?.images[0];
 
           /// cover is the first image, if we haven't downloaded first image, then return a [UIConfig.loadingAnimation]
           if (image?.downloadStatus != DownloadStatus.downloaded) {
@@ -284,7 +368,9 @@ class GalleryListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
             galleryImage: image!,
             containerWidth: UIConfig.downloadPageCoverWidth,
             containerHeight: UIConfig.downloadPageCoverHeight,
-            borderRadius: BorderRadius.circular(UIConfig.downloadPageCardBorderRadius),
+            borderRadius: BorderRadius.circular(ThemeConfig.isApple
+                ? 0
+                : UIConfig.downloadPageCardBorderRadius),
             fit: BoxFit.fitWidth,
             maxBytes: 2 * 1024 * 1024,
           );
@@ -301,7 +387,8 @@ class GalleryListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
         child: Stack(
           children: [
             Container(
-              padding: const EdgeInsets.only(left: 6, right: 10, bottom: 6, top: 6),
+              padding:
+                  const EdgeInsets.only(left: 6, right: 10, bottom: 6, top: 6),
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
@@ -313,7 +400,8 @@ class GalleryListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
                 ],
               ),
             ),
-            if (state.selectedGids.contains(gallery.gid)) const Positioned(child: Center(child: Icon(Icons.check_circle))),
+            if (state.selectedGids.contains(gallery.gid))
+              const Positioned(child: Center(child: Icon(Icons.check_circle))),
           ],
         ),
       ),
@@ -328,7 +416,8 @@ class GalleryListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
           gallery.title,
           maxLines: 2,
           overflow: TextOverflow.ellipsis,
-          style: const TextStyle(fontSize: UIConfig.downloadPageCardTitleSize, height: 1.2),
+          style: const TextStyle(
+              fontSize: UIConfig.downloadPageCardTitleSize, height: 1.2),
         ),
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -337,11 +426,17 @@ class GalleryListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
             if (gallery.uploader != null)
               Text(
                 gallery.uploader!,
-                style: TextStyle(fontSize: UIConfig.downloadPageCardTextSize, color: UIConfig.downloadPageCardTextColor(context)),
+                style: TextStyle(
+                    fontSize: UIConfig.downloadPageCardTextSize,
+                    color: UIConfig.downloadPageCardTextColor(context)),
               ),
             Text(
-              preferenceSetting.showUtcTime.isTrue ? gallery.publishTime : DateUtil.transformUtc2LocalTimeString(gallery.publishTime),
-              style: TextStyle(fontSize: UIConfig.downloadPageCardTextSize, color: UIConfig.downloadPageCardTextColor(context)),
+              preferenceSetting.showUtcTime.isTrue
+                  ? gallery.publishTime
+                  : DateUtil.transformUtc2LocalTimeString(gallery.publishTime),
+              style: TextStyle(
+                  fontSize: UIConfig.downloadPageCardTextSize,
+                  color: UIConfig.downloadPageCardTextColor(context)),
             ),
           ],
         ).marginOnly(top: 5),
@@ -378,16 +473,21 @@ class GalleryListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
       ),
       child: Text(
         'original'.tr,
-        style: TextStyle(color: UIConfig.resumePauseButtonColor(context), fontWeight: FontWeight.bold, fontSize: 9),
+        style: TextStyle(
+            color: UIConfig.resumePauseButtonColor(context),
+            fontWeight: FontWeight.bold,
+            fontSize: 9),
       ),
     );
   }
 
-  Widget _buildSuperResolutionLabel(BuildContext context, GalleryDownloadedData gallery) {
+  Widget _buildSuperResolutionLabel(
+      BuildContext context, GalleryDownloadedData gallery) {
     return GetBuilder<srs.SuperResolutionService>(
       id: '${srs.SuperResolutionService.superResolutionId}::${gallery.gid}',
       builder: (_) {
-        srs.SuperResolutionInfo? superResolutionInfo = superResolutionService.get(gallery.gid, srs.SuperResolutionType.gallery);
+        srs.SuperResolutionInfo? superResolutionInfo = superResolutionService
+            .get(gallery.gid, srs.SuperResolutionType.gallery);
 
         if (superResolutionInfo == null) {
           return const SizedBox();
@@ -397,20 +497,30 @@ class GalleryListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
           margin: const EdgeInsets.symmetric(horizontal: 6),
           padding: const EdgeInsets.symmetric(horizontal: 4),
           decoration: BoxDecoration(
-            borderRadius: superResolutionInfo.status == srs.SuperResolutionStatus.success ? null : BorderRadius.circular(4),
+            borderRadius:
+                superResolutionInfo.status == srs.SuperResolutionStatus.success
+                    ? null
+                    : BorderRadius.circular(4),
             border: Border.all(color: UIConfig.resumePauseButtonColor(context)),
-            shape: superResolutionInfo.status == srs.SuperResolutionStatus.success ? BoxShape.circle : BoxShape.rectangle,
+            shape:
+                superResolutionInfo.status == srs.SuperResolutionStatus.success
+                    ? BoxShape.circle
+                    : BoxShape.rectangle,
           ),
           child: Text(
             superResolutionInfo.status == srs.SuperResolutionStatus.paused
                 ? 'AI'
-                : superResolutionInfo.status == srs.SuperResolutionStatus.success
+                : superResolutionInfo.status ==
+                        srs.SuperResolutionStatus.success
                     ? 'AI'
                     : 'AI(${superResolutionInfo.imageStatuses.fold<int>(0, (previousValue, element) => previousValue + (element == srs.SuperResolutionStatus.success ? 1 : 0))}/${superResolutionInfo.imageStatuses.length})',
             style: TextStyle(
               fontSize: 9,
               color: UIConfig.resumePauseButtonColor(context),
-              decoration: superResolutionInfo.status == srs.SuperResolutionStatus.paused ? TextDecoration.lineThrough : null,
+              decoration:
+                  superResolutionInfo.status == srs.SuperResolutionStatus.paused
+                      ? TextDecoration.lineThrough
+                      : null,
             ),
           ),
         );
@@ -419,22 +529,39 @@ class GalleryListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
   }
 
   Widget _buildPriority(BuildContext context, GalleryDownloadedData gallery) {
-    int? priority = logic.downloadService.galleryDownloadInfos[gallery.gid]?.priority;
+    int? priority =
+        logic.downloadService.galleryDownloadInfos[gallery.gid]?.priority;
     if (priority == null) {
       return const SizedBox();
     }
 
     switch (priority) {
       case 1:
-        return Text('①', style: TextStyle(color: UIConfig.resumePauseButtonColor(context), fontWeight: FontWeight.bold)).marginSymmetric(horizontal: 6);
+        return Text('①',
+                style: TextStyle(
+                    color: UIConfig.resumePauseButtonColor(context),
+                    fontWeight: FontWeight.bold))
+            .marginSymmetric(horizontal: 6);
       case 2:
-        return Text('②', style: TextStyle(color: UIConfig.resumePauseButtonColor(context), fontWeight: FontWeight.bold)).marginSymmetric(horizontal: 6);
+        return Text('②',
+                style: TextStyle(
+                    color: UIConfig.resumePauseButtonColor(context),
+                    fontWeight: FontWeight.bold))
+            .marginSymmetric(horizontal: 6);
       case 3:
-        return Text('③', style: TextStyle(color: UIConfig.resumePauseButtonColor(context), fontWeight: FontWeight.bold)).marginSymmetric(horizontal: 6);
+        return Text('③',
+                style: TextStyle(
+                    color: UIConfig.resumePauseButtonColor(context),
+                    fontWeight: FontWeight.bold))
+            .marginSymmetric(horizontal: 6);
       case GalleryDownloadService.defaultDownloadGalleryPriority:
         return const SizedBox();
       case 5:
-        return Text('⑤', style: TextStyle(color: UIConfig.resumePauseButtonColor(context), fontWeight: FontWeight.bold)).marginSymmetric(horizontal: 6);
+        return Text('⑤',
+                style: TextStyle(
+                    color: UIConfig.resumePauseButtonColor(context),
+                    fontWeight: FontWeight.bold))
+            .marginSymmetric(horizontal: 6);
       default:
         return const SizedBox();
     }
@@ -444,7 +571,8 @@ class GalleryListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
     return GetBuilder<GalleryDownloadService>(
       id: '${logic.downloadService.galleryDownloadProgressId}::${gallery.gid}',
       builder: (_) {
-        DownloadStatus downloadStatus = logic.downloadService.galleryDownloadInfos[gallery.gid]!.downloadProgress.downloadStatus;
+        DownloadStatus downloadStatus = logic.downloadService
+            .galleryDownloadInfos[gallery.gid]!.downloadProgress.downloadStatus;
         return GestureDetector(
           onTap: () {
             downloadStatus == DownloadStatus.paused
@@ -469,24 +597,31 @@ class GalleryListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
     return GetBuilder<GalleryDownloadService>(
       id: '${logic.downloadService.galleryDownloadProgressId}::${gallery.gid}',
       builder: (_) {
-        GalleryDownloadProgress downloadProgress = logic.downloadService.galleryDownloadInfos[gallery.gid]!.downloadProgress;
-        GalleryDownloadSpeedComputer speedComputer = logic.downloadService.galleryDownloadInfos[gallery.gid]!.speedComputer;
+        GalleryDownloadProgress downloadProgress = logic.downloadService
+            .galleryDownloadInfos[gallery.gid]!.downloadProgress;
+        GalleryDownloadSpeedComputer speedComputer = logic
+            .downloadService.galleryDownloadInfos[gallery.gid]!.speedComputer;
         return Column(
           children: [
             Row(
               children: [
-                if (downloadProgress.downloadStatus == DownloadStatus.downloading)
+                if (downloadProgress.downloadStatus ==
+                    DownloadStatus.downloading)
                   GetBuilder<GalleryDownloadService>(
                     id: '${logic.downloadService.galleryDownloadSpeedComputerId}::${gallery.gid}',
                     builder: (_) => Text(
                       speedComputer.speed,
-                      style: TextStyle(fontSize: UIConfig.downloadPageCardTextSize, color: UIConfig.downloadPageCardTextColor(context)),
+                      style: TextStyle(
+                          fontSize: UIConfig.downloadPageCardTextSize,
+                          color: UIConfig.downloadPageCardTextColor(context)),
                     ),
                   ),
                 const Expanded(child: SizedBox()),
                 Text(
                   '${downloadProgress.curCount}/${downloadProgress.totalCount}',
-                  style: TextStyle(fontSize: UIConfig.downloadPageCardTextSize, color: UIConfig.downloadPageCardTextColor(context)),
+                  style: TextStyle(
+                      fontSize: UIConfig.downloadPageCardTextSize,
+                      color: UIConfig.downloadPageCardTextColor(context)),
                 ),
               ],
             ),
@@ -494,7 +629,8 @@ class GalleryListDownloadPage extends StatelessWidget with Scroll2TopPageMixin, 
               SizedBox(
                 height: 3,
                 child: LinearProgressIndicator(
-                  value: downloadProgress.curCount / downloadProgress.totalCount,
+                  value:
+                      downloadProgress.curCount / downloadProgress.totalCount,
                   color: UIConfig.downloadPageProgressIndicatorColor(context),
                 ),
               ).marginOnly(top: 4),

--- a/lib/src/pages/download/list/local/local_gallery_list_page.dart
+++ b/lib/src/pages/download/list/local/local_gallery_list_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:get/get.dart';
+import 'package:jhentai/src/config/theme_config.dart';
 import 'package:jhentai/src/service/local_gallery_service.dart';
 import 'package:jhentai/src/widget/fade_slide_widget.dart';
 import 'package:jhentai/src/widget/loading_state_indicator.dart';
@@ -20,8 +21,10 @@ import 'local_gallery_list_page_state.dart';
 class LocalGalleryListPage extends StatelessWidget with Scroll2TopPageMixin {
   LocalGalleryListPage({Key? key}) : super(key: key);
 
-  final LocalGalleryListPageLogic logic = Get.put(LocalGalleryListPageLogic(), permanent: true);
-  final LocalGalleryListPageState state = Get.find<LocalGalleryListPageLogic>().state;
+  final LocalGalleryListPageLogic logic =
+      Get.put(LocalGalleryListPageLogic(), permanent: true);
+  final LocalGalleryListPageState state =
+      Get.find<LocalGalleryListPageLogic>().state;
 
   @override
   Scroll2TopLogicMixin get scroll2TopLogic => logic;
@@ -35,7 +38,8 @@ class LocalGalleryListPage extends StatelessWidget with Scroll2TopPageMixin {
       appBar: buildAppBar(context),
       body: buildBody(context),
       floatingActionButton: buildFloatingActionButton(),
-      floatingActionButtonLocation: GlassAwareFloatingActionButtonLocation(UIConfig.liquidGlassNavBarRaise(context)),
+      floatingActionButtonLocation: GlassAwareFloatingActionButtonLocation(
+          UIConfig.liquidGlassNavBarRaise(context)),
     );
   }
 
@@ -43,10 +47,15 @@ class LocalGalleryListPage extends StatelessWidget with Scroll2TopPageMixin {
     return AppBar(
       centerTitle: true,
       titleSpacing: 0,
-      title: const DownloadPageSegmentControl(galleryType: DownloadPageGalleryType.local),
+      title: const DownloadPageSegmentControl(
+          galleryType: DownloadPageGalleryType.local),
       leading: IconButton(
         icon: const Icon(Icons.help),
-        onPressed: () => toast((GetPlatform.isIOS || GetPlatform.isMacOS) ? 'localGalleryHelpInfo4iOSAndMacOS'.tr : 'localGalleryHelpInfo'.tr, isShort: false),
+        onPressed: () => toast(
+            (GetPlatform.isIOS || GetPlatform.isMacOS)
+                ? 'localGalleryHelpInfo4iOSAndMacOS'.tr
+                : 'localGalleryHelpInfo'.tr,
+            isShort: false),
       ),
       actions: [
         PopupMenuButton(
@@ -56,21 +65,31 @@ class LocalGalleryListPage extends StatelessWidget with Scroll2TopPageMixin {
                 value: 0,
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
-                  children: [const Icon(Icons.grid_view), const SizedBox(width: 12), Text('switch2GridMode'.tr)],
+                  children: [
+                    const Icon(Icons.grid_view),
+                    const SizedBox(width: 12),
+                    Text('switch2GridMode'.tr)
+                  ],
                 ),
               ),
               PopupMenuItem(
                 value: 1,
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
-                  children: [const Icon(Icons.refresh), const SizedBox(width: 12), Text('refresh'.tr)],
+                  children: [
+                    const Icon(Icons.refresh),
+                    const SizedBox(width: 12),
+                    Text('refresh'.tr)
+                  ],
                 ),
               ),
             ];
           },
           onSelected: (value) {
             if (value == 0) {
-              DownloadPageBodyTypeChangeNotification(bodyType: DownloadPageBodyType.grid).dispatch(context);
+              DownloadPageBodyTypeChangeNotification(
+                      bodyType: DownloadPageBodyType.grid)
+                  .dispatch(context);
             }
             if (value == 1) {
               logic.handleRefreshLocalGallery();
@@ -88,13 +107,15 @@ class LocalGalleryListPage extends StatelessWidget with Scroll2TopPageMixin {
         id: logic.bodyId,
         builder: (_) => LoadingStateIndicator(
           loadingState: localGalleryService.loadingState,
-          successWidgetBuilder: () => NotificationListener<UserScrollNotification>(
+          successWidgetBuilder: () =>
+              NotificationListener<UserScrollNotification>(
             onNotification: logic.onUserScroll,
             child: EHWheelSpeedController(
               controller: state.scrollController,
               child: ListView.builder(
                 controller: state.scrollController,
-                padding: EdgeInsets.only(bottom: 80 + UIConfig.liquidGlassNavContentInset(context)),
+                padding: EdgeInsets.only(
+                    bottom: 80 + UIConfig.liquidGlassNavContentInset(context)),
                 itemCount: logic.computeItemCount(),
                 itemBuilder: (context, index) {
                   if (logic.isAtRootPath) {
@@ -111,7 +132,8 @@ class LocalGalleryListPage extends StatelessWidget with Scroll2TopPageMixin {
                     return childDirectoryItemBuilder(context, index);
                   }
 
-                  return galleryItemBuilder(context, index - logic.computeCurrentDirectoryCount());
+                  return galleryItemBuilder(
+                      context, index - logic.computeCurrentDirectoryCount());
                 },
               ),
             ),
@@ -129,7 +151,9 @@ class LocalGalleryListPage extends StatelessWidget with Scroll2TopPageMixin {
       onTap: () => logic.pushRoute(childPath),
       child: _buildDirectory(
         context,
-        logic.isAtRootPath ? childPath : p.relative(childPath, from: state.currentPath),
+        logic.isAtRootPath
+            ? childPath
+            : p.relative(childPath, from: state.currentPath),
         Icons.folder_special,
       ).marginAll(5),
     );
@@ -139,7 +163,8 @@ class LocalGalleryListPage extends StatelessWidget with Scroll2TopPageMixin {
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTap: logic.backRoute,
-      child: _buildDirectory(context, '/..', Icons.keyboard_return).marginAll(5),
+      child:
+          _buildDirectory(context, '/..', Icons.keyboard_return).marginAll(5),
     );
   }
 
@@ -151,27 +176,46 @@ class LocalGalleryListPage extends StatelessWidget with Scroll2TopPageMixin {
       onTap: () => logic.pushRoute(childPath),
       child: _buildDirectory(
         context,
-        logic.isAtRootPath ? childPath : p.relative(childPath, from: state.currentPath),
+        logic.isAtRootPath
+            ? childPath
+            : p.relative(childPath, from: state.currentPath),
         Icons.folder_open,
       ).marginAll(5),
     );
   }
 
-  Widget _buildDirectory(BuildContext context, String displayPath, IconData iconData) {
+  Widget _buildDirectory(
+      BuildContext context, String displayPath, IconData iconData) {
     return Container(
       height: UIConfig.groupListHeight,
       decoration: BoxDecoration(
-        color: UIConfig.groupListColor(context),
-        boxShadow: [if (!Get.isDarkMode) UIConfig.groupListShadow(context)],
-        borderRadius: BorderRadius.circular(15),
+        color: ThemeConfig.isApple
+            ? Theme.of(context)
+                .colorScheme
+                .surfaceContainerHighest
+                .withValues(alpha: 0.48)
+            : UIConfig.groupListColor(context),
+        boxShadow: ThemeConfig.isApple
+            ? null
+            : [if (!Get.isDarkMode) UIConfig.groupListShadow(context)],
+        borderRadius: BorderRadius.circular(ThemeConfig.isApple ? 8 : 15),
+        border: ThemeConfig.isApple
+            ? Border.all(
+                color: Theme.of(context).dividerColor.withValues(alpha: 0.6),
+                width: 0.5)
+            : null,
       ),
       padding: const EdgeInsets.only(right: 40),
       child: ClipRRect(
-        borderRadius: BorderRadius.circular(15),
+        borderRadius: BorderRadius.circular(ThemeConfig.isApple ? 8 : 15),
         child: Row(
           children: [
-            SizedBox(width: UIConfig.downloadPageGroupHeaderWidth, child: Center(child: Icon(iconData))),
-            Expanded(child: Text(logic.transformDisplayPath(displayPath), maxLines: 1, overflow: TextOverflow.ellipsis))
+            SizedBox(
+                width: UIConfig.downloadPageGroupHeaderWidth,
+                child: Center(child: Icon(iconData))),
+            Expanded(
+                child: Text(logic.transformDisplayPath(displayPath),
+                    maxLines: 1, overflow: TextOverflow.ellipsis))
           ],
         ),
       ),
@@ -179,21 +223,26 @@ class LocalGalleryListPage extends StatelessWidget with Scroll2TopPageMixin {
   }
 
   Widget galleryItemBuilder(BuildContext context, int index) {
-    LocalGallery gallery = localGalleryService.path2GalleryDir[state.currentPath]![index];
+    LocalGallery gallery =
+        localGalleryService.path2GalleryDir[state.currentPath]![index];
 
     return Slidable(
       key: Key(gallery.title),
       endActionPane: _buildEndActionPane(context, gallery),
       child: GestureDetector(
-        onSecondaryTapDown: (details) => logic.showBottomSheet(gallery, context, position: details.globalPosition),
-        onLongPressStart: (details) => logic.showBottomSheet(gallery, context, position: details.globalPosition),
+        onSecondaryTapDown: (details) => logic.showBottomSheet(gallery, context,
+            position: details.globalPosition),
+        onLongPressStart: (details) => logic.showBottomSheet(gallery, context,
+            position: details.globalPosition),
         child: FadeSlideWidget(
           show: !state.removedGalleryTitles.contains(gallery.title),
-          child: _buildGallery(gallery, context).marginAll(5),
+          child: _buildGallery(gallery, context)
+              .marginAll(ThemeConfig.isApple ? 0 : 5),
           afterAnimation: (bool show, bool isInit) {
             if (!show && !isInit) {
               Get.engine.addPostFrameCallback(
-                (_) => localGalleryService.deleteGallery(gallery, state.currentPath),
+                (_) => localGalleryService.deleteGallery(
+                    gallery, state.currentPath),
               );
               state.removedGalleryTitles.remove(gallery.title);
             }
@@ -222,10 +271,20 @@ class LocalGalleryListPage extends StatelessWidget with Scroll2TopPageMixin {
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTap: () => logic.goToReadPage(gallery),
-      child: SizedBox(
+      child: Container(
         height: UIConfig.downloadPageCardHeight,
+        decoration: ThemeConfig.isApple
+            ? BoxDecoration(
+                border: Border(
+                    bottom: BorderSide(
+                        width: 0.5,
+                        color: Theme.of(context)
+                            .dividerColor
+                            .withValues(alpha: 0.7))),
+              )
+            : null,
         child: ClipRRect(
-          borderRadius: BorderRadius.circular(15),
+          borderRadius: BorderRadius.circular(ThemeConfig.isApple ? 0 : 15),
           child: Row(
             children: [
               _buildCover(gallery, context),
@@ -252,7 +311,11 @@ class LocalGalleryListPage extends StatelessWidget with Scroll2TopPageMixin {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(gallery.title, maxLines: 3, overflow: TextOverflow.ellipsis, style: const TextStyle(fontSize: UIConfig.downloadPageCardTitleSize, height: 1.2)),
+        Text(gallery.title,
+            maxLines: 3,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(
+                fontSize: UIConfig.downloadPageCardTitleSize, height: 1.2)),
       ],
     ).paddingOnly(left: 6, right: 10, top: 8, bottom: 5);
   }

--- a/lib/src/pages/download/list/local/local_gallery_list_page.dart
+++ b/lib/src/pages/download/list/local/local_gallery_list_page.dart
@@ -33,8 +33,9 @@ class LocalGalleryListPage extends StatelessWidget with Scroll2TopPageMixin {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: buildAppBar(context),
-      body: buildBody(),
+      body: buildBody(context),
       floatingActionButton: buildFloatingActionButton(),
+      floatingActionButtonLocation: GlassAwareFloatingActionButtonLocation(UIConfig.liquidGlassNavBarRaise(context)),
     );
   }
 
@@ -80,7 +81,7 @@ class LocalGalleryListPage extends StatelessWidget with Scroll2TopPageMixin {
     );
   }
 
-  Widget buildBody() {
+  Widget buildBody(BuildContext context) {
     return GetBuilder<LocalGalleryService>(
       id: localGalleryService.galleryCountChangedId,
       builder: (_) => GetBuilder<LocalGalleryListPageLogic>(
@@ -93,7 +94,7 @@ class LocalGalleryListPage extends StatelessWidget with Scroll2TopPageMixin {
               controller: state.scrollController,
               child: ListView.builder(
                 controller: state.scrollController,
-                padding: const EdgeInsets.only(bottom: 80),
+                padding: EdgeInsets.only(bottom: 80 + UIConfig.liquidGlassNavContentInset(context)),
                 itemCount: logic.computeItemCount(),
                 itemBuilder: (context, index) {
                   if (logic.isAtRootPath) {

--- a/lib/src/pages/gallerys/dashboard/dashboard_page.dart
+++ b/lib/src/pages/gallerys/dashboard/dashboard_page.dart
@@ -70,7 +70,7 @@ class DashboardPage extends BasePage {
               _buildPopular(),
               _buildGalleryDesc(context),
               _buildGalleryBody(context),
-              super.buildLoadMoreIndicator(),
+              super.buildLoadMoreIndicator(context),
             ],
           ),
         ),

--- a/lib/src/pages/gallerys/simple/gallerys_page.dart
+++ b/lib/src/pages/gallerys/simple/gallerys_page.dart
@@ -1,17 +1,32 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:jhentai/src/config/theme_config.dart';
 import 'package:jhentai/src/pages/gallerys/simple/gallerys_page_logic.dart';
 import 'package:jhentai/src/pages/gallerys/simple/gallerys_page_state.dart';
 import '../../base/base_page.dart';
 
 /// For desktop layout
 class GallerysPage extends BasePage {
-  const GallerysPage({Key? key}) : super(key: key, showFilterButton: true, showScroll2TopButton: true);
+  const GallerysPage({Key? key})
+      : super(key: key, showFilterButton: true, showScroll2TopButton: true);
 
   @override
-  GallerysPageLogic get logic => Get.put<GallerysPageLogic>(GallerysPageLogic(), permanent: true);
+  GallerysPageLogic get logic =>
+      Get.put<GallerysPageLogic>(GallerysPageLogic(), permanent: true);
 
   @override
   GallerysPageState get state => Get.find<GallerysPageLogic>().state;
+
+  @override
+  AppBar? buildAppBar(BuildContext context) {
+    if (!ThemeConfig.isApple) {
+      return super.buildAppBar(context);
+    }
+    return AppBar(
+      title: Text('home'.tr),
+      centerTitle: true,
+      actions: super.buildAppBarActions(),
+    );
+  }
 }

--- a/lib/src/pages/layout/desktop/desktop_home_page.dart
+++ b/lib/src/pages/layout/desktop/desktop_home_page.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:jhentai/src/config/theme_config.dart';
 
 import 'desktop_layout_page_logic.dart';
 import 'desktop_layout_page_state.dart';
@@ -18,11 +19,83 @@ class DesktopHomePage extends StatelessWidget {
       builder: (_) => Stack(
         children: state.icons
             .where((icon) => icon.shouldRender)
-            .mapIndexed((index, icon) => Offstage(
-                  offstage: state.selectedTabOrder != index,
-                  child: icon.page.call(),
-                ))
+            .mapIndexed(
+              (index, icon) => _DesktopTabLayer(
+                active: state.selectedTabOrder == index,
+                child: icon.page.call(),
+              ),
+            )
             .toList(),
+      ),
+    );
+  }
+}
+
+/// Keeps desktop sections alive like the old [Offstage] implementation, while
+/// giving each section a short, macOS-style cross-fade when the icon rail
+/// changes selection.
+class _DesktopTabLayer extends StatefulWidget {
+  const _DesktopTabLayer({required this.active, required this.child});
+
+  final bool active;
+  final Widget child;
+
+  @override
+  State<_DesktopTabLayer> createState() => _DesktopTabLayerState();
+}
+
+class _DesktopTabLayerState extends State<_DesktopTabLayer> {
+  static const Duration _transitionDuration = Duration(milliseconds: 220);
+  bool _visible = false;
+  late bool _keepTicking = widget.active;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.active) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          setState(() => _visible = true);
+        }
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant _DesktopTabLayer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.active != oldWidget.active) {
+      if (widget.active) {
+        setState(() {
+          _keepTicking = true;
+          _visible = true;
+        });
+      } else {
+        setState(() => _visible = false);
+        Future<void>.delayed(_transitionDuration, () {
+          if (mounted && !widget.active) {
+            setState(() => _keepTicking = false);
+          }
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!ThemeConfig.isApple) {
+      return Offstage(offstage: !widget.active, child: widget.child);
+    }
+    return IgnorePointer(
+      ignoring: !widget.active,
+      child: TickerMode(
+        enabled: _keepTicking,
+        child: AnimatedOpacity(
+          duration: _transitionDuration,
+          curve: Curves.easeOutCubic,
+          opacity: _visible ? 1 : 0,
+          child: widget.child,
+        ),
       ),
     );
   }

--- a/lib/src/pages/layout/desktop/desktop_layout_page.dart
+++ b/lib/src/pages/layout/desktop/desktop_layout_page.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_resizable_container/flutter_resizable_container.dart';
 import 'package:get/get.dart';
+import 'package:macos_window_utils/widgets/transparent_macos_sidebar.dart';
 import 'package:jhentai/src/pages/home_page.dart';
 import 'package:jhentai/src/pages/layout/desktop/desktop_home_page.dart';
 import 'package:jhentai/src/pages/layout/desktop/desktop_layout_page_state.dart';
 
+import '../../../config/theme_config.dart';
 import '../../../config/ui_config.dart';
 import '../../../routes/routes.dart';
 import '../../../service/windows_service.dart';
@@ -23,7 +25,10 @@ class DesktopLayoutPage extends StatelessWidget {
     return Row(
       children: [
         _leftTabBar(context),
-        VerticalDivider(width: 1, color: UIConfig.layoutDividerColor(context)),
+        VerticalDivider(
+          width: 1,
+          color: ThemeConfig.isApple ? Theme.of(context).colorScheme.outline : UIConfig.layoutDividerColor(context),
+        ),
         Expanded(
           child: _buildDoubleColumn(context),
         ),
@@ -32,10 +37,14 @@ class DesktopLayoutPage extends StatelessWidget {
   }
 
   Widget _leftTabBar(BuildContext context) {
-    return Material(
+    final bool isMacOS = GetPlatform.isMacOS;
+    Widget bar = Material(
+      color: isMacOS ? Colors.transparent : null,
       child: Container(
         width: UIConfig.desktopLeftTabBarWidth,
-        color: UIConfig.backGroundColor(context),
+        color: isMacOS
+            ? UIConfig.desktopSideBarColor(context).withValues(alpha: 0.55)
+            : (ThemeConfig.isApple ? UIConfig.desktopSideBarColor(context) : UIConfig.backGroundColor(context)),
         child: GetBuilder<DesktopLayoutPageLogic>(
           id: logic.tabBarId,
           builder: (_) => ScrollConfiguration(
@@ -50,6 +59,13 @@ class DesktopLayoutPage extends StatelessWidget {
         ),
       ),
     );
+
+    if (isMacOS) {
+      /// Native macOS translucent sidebar (NSVisualEffectView .sidebar material),
+      /// showing the desktop through a frosted surface.
+      bar = TransparentMacOSSidebar(child: bar);
+    }
+    return bar;
   }
 
   Widget _tabBarIcon(BuildContext context, int index) {
@@ -61,16 +77,33 @@ class DesktopLayoutPage extends StatelessWidget {
         children: [
           Expanded(
             child: Center(
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  border: state.selectedTabIndex == index ? Border(left: BorderSide(width: 3, color: UIConfig.desktopLeftTabIconColor(context))) : null,
-                ),
-                child: IconButton(
-                  onPressed: () => logic.handleTapTabBarButton(index),
-                  icon: state.selectedTabIndex == index ? state.icons[index].selectedIcon : state.icons[index].unselectedIcon,
-                  color: UIConfig.desktopLeftTabIconColor(context),
-                ),
-              ),
+              child: ThemeConfig.isApple
+                  ? Container(
+                      margin: const EdgeInsets.symmetric(horizontal: 5),
+                      decoration: BoxDecoration(
+                        color: state.selectedTabIndex == index
+                            ? Theme.of(context).colorScheme.primary
+                            : (state.hoveringTabIndex == index ? Theme.of(context).colorScheme.surfaceContainerHighest : Colors.transparent),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: IconButton(
+                        onPressed: () => logic.handleTapTabBarButton(index),
+                        icon: state.selectedTabIndex == index ? state.icons[index].selectedIcon : state.icons[index].unselectedIcon,
+                        color: state.selectedTabIndex == index ? Colors.white : Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    )
+                  : DecoratedBox(
+                      decoration: BoxDecoration(
+                        border: state.selectedTabIndex == index
+                            ? Border(left: BorderSide(width: 3, color: UIConfig.desktopLeftTabIconColor(context)))
+                            : null,
+                      ),
+                      child: IconButton(
+                        onPressed: () => logic.handleTapTabBarButton(index),
+                        icon: state.selectedTabIndex == index ? state.icons[index].selectedIcon : state.icons[index].unselectedIcon,
+                        color: UIConfig.desktopLeftTabIconColor(context),
+                      ),
+                    ),
             ),
           ),
           SizedBox(

--- a/lib/src/pages/layout/desktop/desktop_layout_page.dart
+++ b/lib/src/pages/layout/desktop/desktop_layout_page.dart
@@ -37,23 +37,27 @@ class DesktopLayoutPage extends StatelessWidget {
   }
 
   Widget _leftTabBar(BuildContext context) {
-    final bool isMacOS = GetPlatform.isMacOS;
+    final bool isMacOS = GetPlatform.isMacOS && ThemeConfig.isApple;
+    final double width = isMacOS ? UIConfig.desktopMacOSLeftTabBarWidth : UIConfig.desktopLeftTabBarWidth;
     Widget bar = Material(
       color: isMacOS ? Colors.transparent : null,
       child: Container(
-        width: UIConfig.desktopLeftTabBarWidth,
+        width: width,
         color: isMacOS
             ? UIConfig.desktopSideBarColor(context).withValues(alpha: 0.55)
             : (ThemeConfig.isApple ? UIConfig.desktopSideBarColor(context) : UIConfig.backGroundColor(context)),
         child: GetBuilder<DesktopLayoutPageLogic>(
           id: logic.tabBarId,
-          builder: (_) => ScrollConfiguration(
-            behavior: UIConfig.scrollBehaviourWithoutScrollBarWithMouse,
-            child: ListView.builder(
-              controller: state.leftTabBarScrollController,
-              itemCount: state.icons.length,
-              itemExtent: UIConfig.desktopLeftTabBarItemHeight,
-              itemBuilder: _tabBarIcon,
+          builder: (_) => Padding(
+            padding: EdgeInsets.only(top: isMacOS ? UIConfig.desktopTitleBarHeight : 0),
+            child: ScrollConfiguration(
+              behavior: UIConfig.scrollBehaviourWithoutScrollBarWithMouse,
+              child: ListView.builder(
+                controller: state.leftTabBarScrollController,
+                itemCount: state.icons.length,
+                itemExtent: UIConfig.desktopLeftTabBarItemHeight,
+                itemBuilder: _tabBarIcon,
+              ),
             ),
           ),
         ),
@@ -78,7 +82,9 @@ class DesktopLayoutPage extends StatelessWidget {
           Expanded(
             child: Center(
               child: ThemeConfig.isApple
-                  ? Container(
+                  ? AnimatedContainer(
+                      duration: const Duration(milliseconds: 180),
+                      curve: Curves.easeOutCubic,
                       margin: const EdgeInsets.symmetric(horizontal: 5),
                       decoration: BoxDecoration(
                         color: state.selectedTabIndex == index
@@ -162,7 +168,7 @@ class DesktopLayoutPage extends StatelessWidget {
       onGenerateInitialRoutes: (_, __) => [
         GetPageRoute(
           settings: const RouteSettings(name: Routes.desktopHome),
-          page: () => DesktopHomePage(),
+          page: DesktopHomePage.new,
           popGesture: false,
           transition: Transition.fadeIn,
           showCupertinoParallax: false,

--- a/lib/src/pages/layout/desktop/desktop_layout_page_state.dart
+++ b/lib/src/pages/layout/desktop/desktop_layout_page_state.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:jhentai/src/config/theme_config.dart';
 import 'package:jhentai/src/extension/list_extension.dart';
 import 'package:jhentai/src/pages/download/download_base_page.dart';
 import 'package:jhentai/src/pages/gallerys/simple/gallerys_page_logic.dart';
@@ -30,7 +31,10 @@ class DesktopLayoutPageState with DoubleTapToRefreshStateMixin {
   int selectedTabIndex = 0;
 
   /// selectedTabIndex in [shouldRender] icons
-  int get selectedTabOrder => icons.where((icon) => icon.shouldRender).toList().indexWhere((icon) => icon.name == icons[selectedTabIndex].name);
+  int get selectedTabOrder => icons
+      .where((icon) => icon.shouldRender)
+      .toList()
+      .indexWhere((icon) => icon.name == icons[selectedTabIndex].name);
   int? hoveringTabIndex;
 
   final ScrollController leftTabBarScrollController = ScrollController();
@@ -43,7 +47,8 @@ class DesktopLayoutPageState with DoubleTapToRefreshStateMixin {
         selectedIcon: Icon(AppIcons.homeFill),
         unselectedIcon: Icon(AppIcons.home),
         page: () => const GallerysPage(),
-        scrollController: () => Get.find<GallerysPageLogic>().state.scrollController,
+        scrollController: () =>
+            Get.find<GallerysPageLogic>().state.scrollController,
         shouldRender: false,
       ),
       TabBarIcon(
@@ -52,8 +57,11 @@ class DesktopLayoutPageState with DoubleTapToRefreshStateMixin {
         selectedIcon: Icon(AppIcons.search, shadows: [Shadow(blurRadius: 2)]),
         unselectedIcon: Icon(AppIcons.search),
         page: () => const DesktopSearchPage(),
-        scrollController: () =>
-            Get.find<DesktopSearchPageLogic>().state.tabLogics[Get.find<DesktopSearchPageLogic>().state.currentTabIndex].state.scrollController,
+        scrollController: () => Get.find<DesktopSearchPageLogic>()
+            .state
+            .tabLogics[Get.find<DesktopSearchPageLogic>().state.currentTabIndex]
+            .state
+            .scrollController,
         shouldRender: true,
       ),
       TabBarIcon(
@@ -61,17 +69,22 @@ class DesktopLayoutPageState with DoubleTapToRefreshStateMixin {
         routeName: Routes.popular,
         selectedIcon: Icon(AppIcons.popularFill),
         unselectedIcon: Icon(AppIcons.popular),
-        page: () => const PopularPage(),
-        scrollController: () => Get.find<PopularPageLogic>().state.scrollController,
+        page: () => ThemeConfig.isApple
+            ? PopularPage(showTitle: true, name: 'popular'.tr)
+            : const PopularPage(),
+        scrollController: () =>
+            Get.find<PopularPageLogic>().state.scrollController,
         shouldRender: false,
       ),
       TabBarIcon(
         name: TabBarIconNameEnum.ranklist,
         routeName: Routes.ranklist,
-        selectedIcon: Icon(AppIcons.ranklistFill, shadows: [Shadow(blurRadius: 2)]),
+        selectedIcon:
+            Icon(AppIcons.ranklistFill, shadows: [Shadow(blurRadius: 2)]),
         unselectedIcon: Icon(AppIcons.ranklist),
         page: () => const RanklistPage(),
-        scrollController: () => Get.find<RanklistPageLogic>().state.scrollController,
+        scrollController: () =>
+            Get.find<RanklistPageLogic>().state.scrollController,
         shouldRender: false,
       ),
       TabBarIcon(
@@ -79,8 +92,11 @@ class DesktopLayoutPageState with DoubleTapToRefreshStateMixin {
         routeName: Routes.favorite,
         selectedIcon: Icon(AppIcons.favoriteFill),
         unselectedIcon: Icon(AppIcons.favorite),
-        page: () => const FavoritePage(),
-        scrollController: () => Get.find<FavoritePageLogic>().state.scrollController,
+        page: () => ThemeConfig.isApple
+            ? FavoritePage(showTitle: true, name: 'favorite'.tr)
+            : const FavoritePage(),
+        scrollController: () =>
+            Get.find<FavoritePageLogic>().state.scrollController,
         shouldRender: false,
       ),
       TabBarIcon(
@@ -89,16 +105,21 @@ class DesktopLayoutPageState with DoubleTapToRefreshStateMixin {
         selectedIcon: Icon(AppIcons.watchedFill),
         unselectedIcon: Icon(AppIcons.watched),
         page: () => const WatchedPage(),
-        scrollController: () => Get.find<WatchedPageLogic>().state.scrollController,
+        scrollController: () =>
+            Get.find<WatchedPageLogic>().state.scrollController,
         shouldRender: false,
       ),
       TabBarIcon(
         name: TabBarIconNameEnum.history,
         routeName: Routes.history,
-        selectedIcon: Icon(AppIcons.historyFill, shadows: [Shadow(blurRadius: 2)]),
+        selectedIcon:
+            Icon(AppIcons.historyFill, shadows: [Shadow(blurRadius: 2)]),
         unselectedIcon: Icon(AppIcons.history),
-        page: () => HistoryPage(),
-        scrollController: () => Get.find<HistoryPageLogic>().state.scrollController,
+        page: () => ThemeConfig.isApple
+            ? HistoryPage(showTitle: true, name: 'history'.tr)
+            : HistoryPage(),
+        scrollController: () =>
+            Get.find<HistoryPageLogic>().state.scrollController,
         shouldRender: false,
       ),
       TabBarIcon(
@@ -119,7 +140,9 @@ class DesktopLayoutPageState with DoubleTapToRefreshStateMixin {
       ),
     ];
 
-    selectedTabIndex = icons.firstIndexWhereOrNull((icon) => icon.name == preferenceSetting.defaultTab.value) ?? 0;
+    selectedTabIndex = icons.firstIndexWhereOrNull(
+            (icon) => icon.name == preferenceSetting.defaultTab.value) ??
+        0;
     icons[selectedTabIndex].shouldRender = true;
   }
 }

--- a/lib/src/pages/layout/desktop/desktop_layout_page_state.dart
+++ b/lib/src/pages/layout/desktop/desktop_layout_page_state.dart
@@ -9,6 +9,7 @@ import 'package:jhentai/src/pages/popular/popular_page.dart';
 import 'package:jhentai/src/pages/setting/setting_page.dart';
 import 'package:jhentai/src/pages/watched/watched_page.dart';
 import 'package:jhentai/src/routes/routes.dart';
+import 'package:jhentai/src/utils/app_icons.dart';
 import 'package:jhentai/src/setting/preference_setting.dart';
 
 import '../../../mixin/double_tap_to_refresh_state_mixin.dart';
@@ -39,8 +40,8 @@ class DesktopLayoutPageState with DoubleTapToRefreshStateMixin {
       TabBarIcon(
         name: TabBarIconNameEnum.home,
         routeName: Routes.gallerys,
-        selectedIcon: const Icon(Icons.home),
-        unselectedIcon: const Icon(Icons.home_outlined),
+        selectedIcon: Icon(AppIcons.homeFill),
+        unselectedIcon: Icon(AppIcons.home),
         page: () => const GallerysPage(),
         scrollController: () => Get.find<GallerysPageLogic>().state.scrollController,
         shouldRender: false,
@@ -48,8 +49,8 @@ class DesktopLayoutPageState with DoubleTapToRefreshStateMixin {
       TabBarIcon(
         name: TabBarIconNameEnum.search,
         routeName: Routes.desktopSearch,
-        selectedIcon: const Icon(Icons.search, shadows: [Shadow(blurRadius: 2)]),
-        unselectedIcon: const Icon(Icons.search),
+        selectedIcon: Icon(AppIcons.search, shadows: [Shadow(blurRadius: 2)]),
+        unselectedIcon: Icon(AppIcons.search),
         page: () => const DesktopSearchPage(),
         scrollController: () =>
             Get.find<DesktopSearchPageLogic>().state.tabLogics[Get.find<DesktopSearchPageLogic>().state.currentTabIndex].state.scrollController,
@@ -58,8 +59,8 @@ class DesktopLayoutPageState with DoubleTapToRefreshStateMixin {
       TabBarIcon(
         name: TabBarIconNameEnum.popular,
         routeName: Routes.popular,
-        selectedIcon: const Icon(Icons.whatshot),
-        unselectedIcon: const Icon(Icons.whatshot_outlined),
+        selectedIcon: Icon(AppIcons.popularFill),
+        unselectedIcon: Icon(AppIcons.popular),
         page: () => const PopularPage(),
         scrollController: () => Get.find<PopularPageLogic>().state.scrollController,
         shouldRender: false,
@@ -67,8 +68,8 @@ class DesktopLayoutPageState with DoubleTapToRefreshStateMixin {
       TabBarIcon(
         name: TabBarIconNameEnum.ranklist,
         routeName: Routes.ranklist,
-        selectedIcon: const Icon(Icons.bar_chart_rounded, shadows: [Shadow(blurRadius: 2)]),
-        unselectedIcon: const Icon(Icons.bar_chart_outlined),
+        selectedIcon: Icon(AppIcons.ranklistFill, shadows: [Shadow(blurRadius: 2)]),
+        unselectedIcon: Icon(AppIcons.ranklist),
         page: () => const RanklistPage(),
         scrollController: () => Get.find<RanklistPageLogic>().state.scrollController,
         shouldRender: false,
@@ -76,8 +77,8 @@ class DesktopLayoutPageState with DoubleTapToRefreshStateMixin {
       TabBarIcon(
         name: TabBarIconNameEnum.favorite,
         routeName: Routes.favorite,
-        selectedIcon: const Icon(Icons.favorite),
-        unselectedIcon: const Icon(Icons.favorite_outline),
+        selectedIcon: Icon(AppIcons.favoriteFill),
+        unselectedIcon: Icon(AppIcons.favorite),
         page: () => const FavoritePage(),
         scrollController: () => Get.find<FavoritePageLogic>().state.scrollController,
         shouldRender: false,
@@ -85,8 +86,8 @@ class DesktopLayoutPageState with DoubleTapToRefreshStateMixin {
       TabBarIcon(
         name: TabBarIconNameEnum.watched,
         routeName: Routes.watched,
-        selectedIcon: const Icon(Icons.visibility),
-        unselectedIcon: const Icon(Icons.visibility_outlined),
+        selectedIcon: Icon(AppIcons.watchedFill),
+        unselectedIcon: Icon(AppIcons.watched),
         page: () => const WatchedPage(),
         scrollController: () => Get.find<WatchedPageLogic>().state.scrollController,
         shouldRender: false,
@@ -94,8 +95,8 @@ class DesktopLayoutPageState with DoubleTapToRefreshStateMixin {
       TabBarIcon(
         name: TabBarIconNameEnum.history,
         routeName: Routes.history,
-        selectedIcon: const Icon(Icons.history, shadows: [Shadow(blurRadius: 2)]),
-        unselectedIcon: const Icon(Icons.history_outlined),
+        selectedIcon: Icon(AppIcons.historyFill, shadows: [Shadow(blurRadius: 2)]),
+        unselectedIcon: Icon(AppIcons.history),
         page: () => HistoryPage(),
         scrollController: () => Get.find<HistoryPageLogic>().state.scrollController,
         shouldRender: false,
@@ -103,16 +104,16 @@ class DesktopLayoutPageState with DoubleTapToRefreshStateMixin {
       TabBarIcon(
         name: TabBarIconNameEnum.download,
         routeName: Routes.download,
-        selectedIcon: const Icon(Icons.download),
-        unselectedIcon: const Icon(Icons.download_outlined),
+        selectedIcon: Icon(AppIcons.downloadFill),
+        unselectedIcon: Icon(AppIcons.download),
         page: () => const DownloadPage(),
         shouldRender: false,
       ),
       TabBarIcon(
         name: TabBarIconNameEnum.setting,
         routeName: Routes.setting,
-        selectedIcon: const Icon(Icons.settings),
-        unselectedIcon: const Icon(Icons.settings_outlined),
+        selectedIcon: Icon(AppIcons.settingsFill),
+        unselectedIcon: Icon(AppIcons.settings),
         page: () => const SettingPage(),
         shouldRender: true,
       ),

--- a/lib/src/pages/layout/mobile_v2/mobile_layout_page_v2.dart
+++ b/lib/src/pages/layout/mobile_v2/mobile_layout_page_v2.dart
@@ -3,6 +3,7 @@ import 'package:collection/collection.dart';
 import 'package:extended_image/extended_image.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:jhentai/src/config/theme_config.dart';
 import 'package:jhentai/src/config/ui_config.dart';
 import 'package:jhentai/src/pages/download/download_base_page.dart';
 import 'package:jhentai/src/pages/layout/mobile_v2/mobile_layout_page_v2_logic.dart';
@@ -13,8 +14,11 @@ import 'package:jhentai/src/pages/setting/setting_page.dart';
 import 'package:jhentai/src/routes/routes.dart';
 import 'package:jhentai/src/service/quick_search_service.dart';
 import 'package:jhentai/src/setting/user_setting.dart';
+import 'package:jhentai/src/utils/app_icons.dart';
 import 'package:jhentai/src/utils/route_util.dart';
 import 'package:jhentai/src/widget/will_pop_interceptor.dart';
+
+import 'package:liquid_glass_easy/liquid_glass_easy.dart';
 
 import '../../../network/eh_request.dart';
 import '../../../setting/preference_setting.dart';
@@ -38,8 +42,18 @@ class MobileLayoutPageV2 extends StatelessWidget {
           drawerEnableOpenDragGesture: preferenceSetting.enableLeftMenuDrawerGesture.isTrue,
           endDrawer: buildRightDrawer(),
           endDrawerEnableOpenDragGesture: preferenceSetting.enableQuickSearchDrawerGesture.isTrue,
-          body: buildBody(),
-          bottomNavigationBar: preferenceSetting.hideBottomBar.isTrue ? null : buildBottomNavigationBar(context),
+          body: ThemeConfig.isApple
+              ? Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    buildBody(),
+                    if (!preferenceSetting.hideBottomBar.value) buildLiquidGlassBottomNavigationBar(context),
+                  ],
+                )
+              : buildBody(),
+          bottomNavigationBar: ThemeConfig.isApple
+              ? null
+              : (preferenceSetting.hideBottomBar.isTrue ? null : buildBottomNavigationBar(context)),
         ),
       ),
     );
@@ -100,6 +114,30 @@ class MobileLayoutPageV2 extends StatelessWidget {
             NavigationDestination(icon: const Icon(Icons.home), label: 'home'.tr),
             NavigationDestination(icon: const Icon(Icons.download), label: 'download'.tr),
             NavigationDestination(icon: const Icon(Icons.settings), label: 'setting'.tr),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget buildLiquidGlassBottomNavigationBar(BuildContext context) {
+    return GetBuilder<MobileLayoutPageV2Logic>(
+      id: logic.bottomNavigationBarId,
+      builder: (_) => LayoutBuilder(
+        builder: (context, constraints) => LiquidGlassBottomNavBar.withImpeller(
+          selectedIndex: state.selectedNavigationIndex,
+          onChanged: logic.handleTapNavigationBarButton,
+          width: (constraints.maxWidth - 32).clamp(0, 420),
+          height: UIConfig.liquidGlassNavBarHeight,
+          margin: EdgeInsets.only(bottom: UIConfig.liquidGlassNavBarMarginBottom),
+          style: LiquidGlassStyle(
+            appearance: const LiquidGlassAppearance(color: Colors.transparent),
+            refraction: const LiquidGlassRefraction(distortion: 0.02, chromaticAberration: 0.0),
+          ),
+          items: [
+            LiquidGlassTabBarItem(icon: AppIcons.home, selectedIcon: AppIcons.homeFill, label: 'home'.tr),
+            LiquidGlassTabBarItem(icon: AppIcons.download, selectedIcon: AppIcons.downloadFill, label: 'download'.tr),
+            LiquidGlassTabBarItem(icon: AppIcons.settings, selectedIcon: AppIcons.settingsFill, label: 'setting'.tr),
           ],
         ),
       ),

--- a/lib/src/pages/layout/mobile_v2/mobile_layout_page_v2.dart
+++ b/lib/src/pages/layout/mobile_v2/mobile_layout_page_v2.dart
@@ -26,8 +26,10 @@ import '../../../widget/eh_alert_dialog.dart';
 import 'notification/tap_tab_bat_button_notification.dart';
 
 class MobileLayoutPageV2 extends StatelessWidget {
-  final MobileLayoutPageV2Logic logic = Get.put(MobileLayoutPageV2Logic(), permanent: true);
-  final MobileLayoutPageV2State state = Get.find<MobileLayoutPageV2Logic>().state;
+  final MobileLayoutPageV2Logic logic =
+      Get.put(MobileLayoutPageV2Logic(), permanent: true);
+  final MobileLayoutPageV2State state =
+      Get.find<MobileLayoutPageV2Logic>().state;
 
   MobileLayoutPageV2({Key? key}) : super(key: key);
 
@@ -37,23 +39,29 @@ class MobileLayoutPageV2 extends StatelessWidget {
       () => WillPopInterceptor(
         child: Scaffold(
           key: MobileLayoutPageV2State.scaffoldKey,
-          drawerEdgeDragWidth: preferenceSetting.drawerGestureEdgeWidth.value.toDouble(),
+          drawerEdgeDragWidth:
+              preferenceSetting.drawerGestureEdgeWidth.value.toDouble(),
           drawer: buildLeftDrawer(context),
-          drawerEnableOpenDragGesture: preferenceSetting.enableLeftMenuDrawerGesture.isTrue,
+          drawerEnableOpenDragGesture:
+              preferenceSetting.enableLeftMenuDrawerGesture.isTrue,
           endDrawer: buildRightDrawer(),
-          endDrawerEnableOpenDragGesture: preferenceSetting.enableQuickSearchDrawerGesture.isTrue,
+          endDrawerEnableOpenDragGesture:
+              preferenceSetting.enableQuickSearchDrawerGesture.isTrue,
           body: ThemeConfig.isApple
               ? Stack(
                   fit: StackFit.expand,
                   children: [
                     buildBody(),
-                    if (!preferenceSetting.hideBottomBar.value) buildLiquidGlassBottomNavigationBar(context),
+                    if (!preferenceSetting.hideBottomBar.value)
+                      buildLiquidGlassBottomNavigationBar(context),
                   ],
                 )
               : buildBody(),
           bottomNavigationBar: ThemeConfig.isApple
               ? null
-              : (preferenceSetting.hideBottomBar.isTrue ? null : buildBottomNavigationBar(context)),
+              : (preferenceSetting.hideBottomBar.isTrue
+                  ? null
+                  : buildBottomNavigationBar(context)),
         ),
       ),
     );
@@ -79,12 +87,17 @@ class MobileLayoutPageV2 extends StatelessWidget {
                     scrollCacheExtent: ScrollCacheExtent.pixels(1000),
                     itemBuilder: (context, index) => ListTile(
                       dense: true,
-                      title: Text(state.icons[index].name.name.tr, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 14)),
+                      title: Text(state.icons[index].name.name.tr,
+                          style: const TextStyle(
+                              fontWeight: FontWeight.bold, fontSize: 14)),
                       selected: state.selectedDrawerTabIndex == index,
-                      selectedTileColor: UIConfig.mobileDrawerSelectedTileColor(context),
+                      selectedTileColor:
+                          UIConfig.mobileDrawerSelectedTileColor(context),
                       leading: state.icons[index].unselectedIcon,
                       shape: const RoundedRectangleBorder(
-                        borderRadius: BorderRadiusDirectional.only(topEnd: Radius.circular(32), bottomEnd: Radius.circular(32)),
+                        borderRadius: BorderRadiusDirectional.only(
+                            topEnd: Radius.circular(32),
+                            bottomEnd: Radius.circular(32)),
                       ),
                       onTap: () => logic.handleTapTabBarButton(index),
                     ).marginOnly(right: 8, top: 2),
@@ -99,7 +112,10 @@ class MobileLayoutPageV2 extends StatelessWidget {
   }
 
   Widget buildRightDrawer() {
-    return Drawer(width: 278, child: QuickSearchPage(scrollController: quickSearchService.drawerScrollController));
+    return Drawer(
+        width: 278,
+        child: QuickSearchPage(
+            scrollController: quickSearchService.drawerScrollController));
   }
 
   Widget buildBottomNavigationBar(BuildContext context) {
@@ -111,9 +127,12 @@ class MobileLayoutPageV2 extends StatelessWidget {
           selectedIndex: state.selectedNavigationIndex,
           onDestinationSelected: logic.handleTapNavigationBarButton,
           destinations: [
-            NavigationDestination(icon: const Icon(Icons.home), label: 'home'.tr),
-            NavigationDestination(icon: const Icon(Icons.download), label: 'download'.tr),
-            NavigationDestination(icon: const Icon(Icons.settings), label: 'setting'.tr),
+            NavigationDestination(
+                icon: const Icon(Icons.home), label: 'home'.tr),
+            NavigationDestination(
+                icon: const Icon(Icons.download), label: 'download'.tr),
+            NavigationDestination(
+                icon: const Icon(Icons.settings), label: 'setting'.tr),
           ],
         ),
       ),
@@ -121,6 +140,16 @@ class MobileLayoutPageV2 extends StatelessWidget {
   }
 
   Widget buildLiquidGlassBottomNavigationBar(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final selectedItemColor = isDark ? Colors.white : Colors.black;
+    final unselectedItemColor = isDark ? Colors.white70 : Colors.black54;
+    final navShape = LiquidGlassShape.roundedRectangle(
+      cornerRadius: 32,
+      borderWidth: isDark ? 0.6 : 0,
+      borderColor: isDark ? Colors.white.withValues(alpha: 0.20) : null,
+      lightIntensity: 0,
+    );
+
     return GetBuilder<MobileLayoutPageV2Logic>(
       id: logic.bottomNavigationBarId,
       builder: (_) => LayoutBuilder(
@@ -129,15 +158,36 @@ class MobileLayoutPageV2 extends StatelessWidget {
           onChanged: logic.handleTapNavigationBarButton,
           width: (constraints.maxWidth - 32).clamp(0, 420),
           height: UIConfig.liquidGlassNavBarHeight,
-          margin: EdgeInsets.only(bottom: UIConfig.liquidGlassNavBarMarginBottom),
+          margin:
+              EdgeInsets.only(bottom: UIConfig.liquidGlassNavBarMarginBottom),
+          itemStyle: LiquidGlassNavItemStyle(
+            selectedColor: selectedItemColor,
+            unselectedColor: unselectedItemColor,
+          ),
           style: LiquidGlassStyle(
-            appearance: const LiquidGlassAppearance(color: Colors.transparent),
-            refraction: const LiquidGlassRefraction(distortion: 0.02, chromaticAberration: 0.0),
+            shape: navShape,
+            appearance: LiquidGlassAppearance(
+              color: Theme.of(context).colorScheme.surface.withValues(
+                    alpha: isDark ? 0.58 : 0.60,
+                  ),
+              blur: const LiquidGlassBlur(sigmaX: 12, sigmaY: 12),
+            ),
+            refraction: const LiquidGlassRefraction(
+                distortion: 0.02, chromaticAberration: 0.0),
           ),
           items: [
-            LiquidGlassTabBarItem(icon: AppIcons.home, selectedIcon: AppIcons.homeFill, label: 'home'.tr),
-            LiquidGlassTabBarItem(icon: AppIcons.download, selectedIcon: AppIcons.downloadFill, label: 'download'.tr),
-            LiquidGlassTabBarItem(icon: AppIcons.settings, selectedIcon: AppIcons.settingsFill, label: 'setting'.tr),
+            LiquidGlassTabBarItem(
+                icon: AppIcons.home,
+                selectedIcon: AppIcons.homeFill,
+                label: 'home'.tr),
+            LiquidGlassTabBarItem(
+                icon: AppIcons.download,
+                selectedIcon: AppIcons.downloadFill,
+                label: 'download'.tr),
+            LiquidGlassTabBarItem(
+                icon: AppIcons.settings,
+                selectedIcon: AppIcons.settingsFill,
+                label: 'setting'.tr),
           ],
         ),
       ),
@@ -151,9 +201,15 @@ class MobileLayoutPageV2 extends StatelessWidget {
           id: logic.bodyId,
           builder: (_) => Stack(
             children: [
-              Offstage(offstage: state.selectedNavigationIndex != 0, child: buildHomeBody()),
-              Offstage(offstage: state.selectedNavigationIndex != 1, child: const DownloadPage()),
-              Offstage(offstage: state.selectedNavigationIndex != 2, child: const SettingPage()),
+              Offstage(
+                  offstage: state.selectedNavigationIndex != 0,
+                  child: buildHomeBody()),
+              Offstage(
+                  offstage: state.selectedNavigationIndex != 1,
+                  child: const DownloadPage()),
+              Offstage(
+                  offstage: state.selectedNavigationIndex != 2,
+                  child: const SettingPage()),
             ],
           ),
         ),
@@ -199,12 +255,22 @@ class EHUserAvatar extends StatelessWidget {
             child: CircleAvatar(
               radius: 32,
               backgroundColor: UIConfig.loginAvatarBackGroundColor(context),
-              foregroundImage: userSetting.avatarImgUrl.value != null ? ExtendedNetworkImageProvider(userSetting.avatarImgUrl.value!, cache: true) : null,
-              child:
-                  Icon(userSetting.hasLoggedIn() ? Icons.face_retouching_natural : Icons.face, color: UIConfig.loginAvatarForeGroundColor(context), size: 32),
+              foregroundImage: userSetting.avatarImgUrl.value != null
+                  ? ExtendedNetworkImageProvider(
+                      userSetting.avatarImgUrl.value!,
+                      cache: true)
+                  : null,
+              child: Icon(
+                  userSetting.hasLoggedIn()
+                      ? Icons.face_retouching_natural
+                      : Icons.face,
+                  color: UIConfig.loginAvatarForeGroundColor(context),
+                  size: 32),
             ),
           ),
-          title: Text(userSetting.nickName.value ?? userSetting.userName.value ?? 'tap2Login'.tr),
+          title: Text(userSetting.nickName.value ??
+              userSetting.userName.value ??
+              'tap2Login'.tr),
           onTap: () async {
             if (!userSetting.hasLoggedIn()) {
               toRoute(Routes.login);

--- a/lib/src/pages/layout/mobile_v2/mobile_layout_page_v2_state.dart
+++ b/lib/src/pages/layout/mobile_v2/mobile_layout_page_v2_state.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:jhentai/src/extension/list_extension.dart';
+import 'package:jhentai/src/utils/app_icons.dart';
 import 'package:jhentai/src/pages/gallerys/dashboard/dashboard_page_logic.dart';
 import 'package:jhentai/src/pages/gallerys/dashboard/simple/simple_dashboard_page_logic.dart';
 import 'package:jhentai/src/pages/search/mobile_v2/search_page_mobile_v2.dart';
@@ -42,8 +43,8 @@ class MobileLayoutPageV2State with DoubleTapToRefreshStateMixin {
       TabBarIcon(
         name: TabBarIconNameEnum.home,
         routeName: Routes.dashboard,
-        selectedIcon: const Icon(Icons.home),
-        unselectedIcon: const Icon(Icons.home_outlined),
+        selectedIcon: Icon(AppIcons.homeFill),
+        unselectedIcon: Icon(AppIcons.home),
         page: () => preferenceSetting.simpleDashboardMode.isTrue ? const SimpleDashboardPage() : const DashboardPage(),
         scrollController: () => preferenceSetting.simpleDashboardMode.isTrue
             ? Get.find<SimpleDashboardPageLogic>().scroll2TopState.scrollController
@@ -53,8 +54,8 @@ class MobileLayoutPageV2State with DoubleTapToRefreshStateMixin {
       TabBarIcon(
         name: TabBarIconNameEnum.search,
         routeName: Routes.mobileV2Search,
-        selectedIcon: const Icon(Icons.search, shadows: [Shadow(blurRadius: 2)]),
-        unselectedIcon: const Icon(Icons.search),
+        selectedIcon: Icon(AppIcons.search, shadows: [Shadow(blurRadius: 2)]),
+        unselectedIcon: Icon(AppIcons.search),
         page: () => SearchPageMobileV2(),
         shouldRender: false,
         enterNewRoute: true,
@@ -62,8 +63,8 @@ class MobileLayoutPageV2State with DoubleTapToRefreshStateMixin {
       TabBarIcon(
         name: TabBarIconNameEnum.popular,
         routeName: Routes.popular,
-        selectedIcon: const Icon(Icons.whatshot),
-        unselectedIcon: const Icon(Icons.whatshot_outlined),
+        selectedIcon: Icon(AppIcons.popularFill),
+        unselectedIcon: Icon(AppIcons.popular),
         page: () => PopularPage(showMenuButton: true, showTitle: true, name: 'popular'.tr),
         scrollController: () => Get.find<PopularPageLogic>().scroll2TopState.scrollController,
         shouldRender: false,
@@ -71,8 +72,8 @@ class MobileLayoutPageV2State with DoubleTapToRefreshStateMixin {
       TabBarIcon(
         name: TabBarIconNameEnum.ranklist,
         routeName: Routes.ranklist,
-        selectedIcon: const Icon(Icons.bar_chart_rounded, shadows: [Shadow(blurRadius: 2)]),
-        unselectedIcon: const Icon(Icons.bar_chart_outlined),
+        selectedIcon: Icon(AppIcons.ranklistFill, shadows: [Shadow(blurRadius: 2)]),
+        unselectedIcon: Icon(AppIcons.ranklist),
         page: () => const RanklistPage(showMenuButton: true, showTitle: true),
         scrollController: () => Get.find<RanklistPageLogic>().scroll2TopState.scrollController,
         shouldRender: false,
@@ -80,8 +81,8 @@ class MobileLayoutPageV2State with DoubleTapToRefreshStateMixin {
       TabBarIcon(
         name: TabBarIconNameEnum.favorite,
         routeName: Routes.favorite,
-        selectedIcon: const Icon(Icons.favorite),
-        unselectedIcon: const Icon(Icons.favorite_outline),
+        selectedIcon: Icon(AppIcons.favoriteFill),
+        unselectedIcon: Icon(AppIcons.favorite),
         page: () => FavoritePage(showMenuButton: true, showTitle: true, name: 'favorite'.tr),
         scrollController: () => Get.find<FavoritePageLogic>().scroll2TopState.scrollController,
         shouldRender: false,
@@ -89,8 +90,8 @@ class MobileLayoutPageV2State with DoubleTapToRefreshStateMixin {
       TabBarIcon(
         name: TabBarIconNameEnum.watched,
         routeName: Routes.watched,
-        selectedIcon: const Icon(Icons.visibility),
-        unselectedIcon: const Icon(Icons.visibility_outlined),
+        selectedIcon: Icon(AppIcons.watchedFill),
+        unselectedIcon: Icon(AppIcons.watched),
         page: () => WatchedPage(showMenuButton: true, showTitle: true, name: 'watched'.tr),
         scrollController: () => Get.find<WatchedPageLogic>().scroll2TopState.scrollController,
         shouldRender: false,
@@ -98,8 +99,8 @@ class MobileLayoutPageV2State with DoubleTapToRefreshStateMixin {
       TabBarIcon(
         name: TabBarIconNameEnum.history,
         routeName: Routes.history,
-        selectedIcon: const Icon(Icons.history, shadows: [Shadow(blurRadius: 2)]),
-        unselectedIcon: const Icon(Icons.history_outlined),
+        selectedIcon: Icon(AppIcons.historyFill, shadows: [Shadow(blurRadius: 2)]),
+        unselectedIcon: Icon(AppIcons.history),
         page: () => HistoryPage(showMenuButton: true, showTitle: true, name: 'history'.tr),
         scrollController: () => Get.find<HistoryPageLogic>().scroll2TopState.scrollController,
         shouldRender: false,
@@ -107,16 +108,16 @@ class MobileLayoutPageV2State with DoubleTapToRefreshStateMixin {
       TabBarIcon(
         name: TabBarIconNameEnum.download,
         routeName: Routes.download,
-        selectedIcon: const Icon(Icons.download),
-        unselectedIcon: const Icon(Icons.download_outlined),
+        selectedIcon: Icon(AppIcons.downloadFill),
+        unselectedIcon: Icon(AppIcons.download),
         page: () => const DownloadPage(),
         shouldRender: false,
       ),
       TabBarIcon(
         name: TabBarIconNameEnum.setting,
         routeName: Routes.setting,
-        selectedIcon: const Icon(Icons.settings),
-        unselectedIcon: const Icon(Icons.settings_outlined),
+        selectedIcon: Icon(AppIcons.settingsFill),
+        unselectedIcon: Icon(AppIcons.settings),
         page: () => const SettingPage(),
         shouldRender: false,
         enterNewRoute: true,

--- a/lib/src/pages/search/desktop/desktop_search_page.dart
+++ b/lib/src/pages/search/desktop/desktop_search_page.dart
@@ -7,6 +7,7 @@ import 'package:jhentai/src/extension/widget_extension.dart';
 import 'package:jhentai/src/widget/eh_wheel_speed_controller.dart';
 import 'package:jhentai/src/widget/fade_slide_widget.dart';
 
+import '../../../config/theme_config.dart';
 import '../../../config/ui_config.dart';
 import '../../../mixin/scroll_to_top_logic_mixin.dart';
 import '../../../mixin/scroll_to_top_page_mixin.dart';
@@ -18,7 +19,9 @@ import 'desktop_search_page_tab_logic.dart';
 class DesktopSearchPage extends StatelessWidget with Scroll2TopPageMixin {
   const DesktopSearchPage({Key? key}) : super(key: key);
 
-  DesktopSearchPageLogic get logic => Get.put<DesktopSearchPageLogic>(DesktopSearchPageLogic(), permanent: true);
+  DesktopSearchPageLogic get logic =>
+      Get.put<DesktopSearchPageLogic>(DesktopSearchPageLogic(),
+          permanent: true);
 
   DesktopSearchPageState get state => Get.find<DesktopSearchPageLogic>().state;
 
@@ -39,7 +42,7 @@ class DesktopSearchPage extends StatelessWidget with Scroll2TopPageMixin {
         body: SafeArea(
           child: Column(
             children: [
-              buildTabBar().marginOnly(bottom: 8),
+              buildTabBar(context).marginOnly(bottom: 8),
               buildTabView(),
             ],
           ),
@@ -49,33 +52,58 @@ class DesktopSearchPage extends StatelessWidget with Scroll2TopPageMixin {
     );
   }
 
-  Widget buildTabBar() {
+  Widget buildTabBar(BuildContext context) {
     return GetBuilder<DesktopSearchPageLogic>(
       id: logic.tabBarId,
       builder: (_) => SizedBox(
         height: UIConfig.desktopSearchTabHeight,
-        child: LayoutBuilder(
-          builder: (context, constraints) => Row(
-            children: [
-              ConstrainedBox(
-                constraints: BoxConstraints(maxWidth: constraints.maxWidth - UIConfig.desktopSearchTabRemainingWidth),
-                child: EHWheelSpeedController(
-                  controller: state.tabController,
-                  child: ListView(
-                    scrollDirection: Axis.horizontal,
-                    controller: state.tabController,
-                    shrinkWrap: true,
-                    children: _buildTabs(context),
-                  ).enableMouseDrag(withScrollBar: false),
+        child: DecoratedBox(
+          decoration: ThemeConfig.isApple
+              ? BoxDecoration(
+                  color: Theme.of(context)
+                      .colorScheme
+                      .surface
+                      .withValues(alpha: 0.45),
+                  border: Border(
+                      bottom: BorderSide(
+                          width: 0.5,
+                          color: Theme.of(context)
+                              .dividerColor
+                              .withValues(alpha: 0.75))),
+                )
+              : const BoxDecoration(),
+          child: LayoutBuilder(
+            builder: (context, constraints) => Row(
+              children: [
+                ConstrainedBox(
+                  constraints: BoxConstraints(
+                      maxWidth: constraints.maxWidth -
+                          UIConfig.desktopSearchTabRemainingWidth),
+                  child: Padding(
+                    // Align the first tab with the search field directly below.
+                    padding: EdgeInsets.only(left: ThemeConfig.isApple ? 8 : 0),
+                    child: EHWheelSpeedController(
+                      controller: state.tabController,
+                      child: ListView(
+                        scrollDirection: Axis.horizontal,
+                        controller: state.tabController,
+                        shrinkWrap: true,
+                        children: _buildTabs(context),
+                      ).enableMouseDrag(withScrollBar: false),
+                    ),
+                  ),
                 ),
-              ),
-              IconButton(
-                onPressed: () => logic.addNewTab(keyword: '', loadImmediately: false),
-                icon: const Icon(Icons.add),
-                constraints: const BoxConstraints.tightFor(width: UIConfig.desktopSearchTabHeight, height: UIConfig.desktopSearchTabHeight),
-                padding: EdgeInsets.zero,
-              ),
-            ],
+                IconButton(
+                  onPressed: () => logic.addNewTab(
+                      keyword: '', loadImmediately: ThemeConfig.isApple),
+                  icon: const Icon(Icons.add),
+                  constraints: const BoxConstraints.tightFor(
+                      width: UIConfig.desktopSearchTabHeight,
+                      height: UIConfig.desktopSearchTabHeight),
+                  padding: EdgeInsets.zero,
+                ),
+              ],
+            ),
           ),
         ),
       ),
@@ -83,7 +111,7 @@ class DesktopSearchPage extends StatelessWidget with Scroll2TopPageMixin {
   }
 
   List<Widget> _buildTabs(BuildContext context) {
-    return state.tabLogics
+    final tabs = state.tabLogics
         .mapIndexed<Widget>(
           (index, tabLogic) => FadeSlideWidget(
             key: ValueKey(tabLogic),
@@ -102,13 +130,22 @@ class DesktopSearchPage extends StatelessWidget with Scroll2TopPageMixin {
                   name: index == state.currentTabIndex
                       ? (tabLogic.state.totalCount != null
                           ? tabLogic.state.totalCount!.toPrintString()
-                          : tabLogic.state.searchConfig.computeFullKeywords().defaultIfEmpty('${'tab'.tr} ${index + 1}'))
-                      : tabLogic.state.searchConfig.computeFullKeywords().defaultIfEmpty('${'tab'.tr} ${index + 1}'),
+                          : tabLogic.state.searchConfig
+                              .computeFullKeywords()
+                              .defaultIfEmpty('${'tab'.tr} ${index + 1}'))
+                      : tabLogic.state.searchConfig
+                          .computeFullKeywords()
+                          .defaultIfEmpty('${'tab'.tr} ${index + 1}'),
                   selected: index == state.currentTabIndex,
-                  selectedColor: UIConfig.desktopSearchTabSelectedBackGroundColor(context),
-                  unSelectedColor: UIConfig.desktopSearchTabUnSelectedBackGroundColor(context),
-                  selectedTextColor: UIConfig.desktopSearchTabSelectedTextColor(context),
-                  unSelectedTextColor: UIConfig.desktopSearchTabUnSelectedTextColor(context),
+                  selectedColor:
+                      UIConfig.desktopSearchTabSelectedBackGroundColor(context),
+                  unSelectedColor:
+                      UIConfig.desktopSearchTabUnSelectedBackGroundColor(
+                          context),
+                  selectedTextColor:
+                      UIConfig.desktopSearchTabSelectedTextColor(context),
+                  unSelectedTextColor:
+                      UIConfig.desktopSearchTabUnSelectedTextColor(context),
                   onTap: () => logic.handleTapTab(index),
                   onDelete: () => logic.deleteTab(index),
                 ),
@@ -116,20 +153,28 @@ class DesktopSearchPage extends StatelessWidget with Scroll2TopPageMixin {
             ),
           ),
         )
-        .toList()
-        .joinNewElementIndexed(
-          (index) => _SearchTabDivider(
-            hasLeftTab: index >= 0,
-            hasRightTab: index != state.tabLogics.length - 1,
-            leftTabIsSelected: index == state.currentTabIndex,
-            rightTabIsSelected: index == state.currentTabIndex - 1,
-            selectedColor: UIConfig.desktopSearchTabSelectedBackGroundColor(context),
-            unSelectedColor: UIConfig.desktopSearchTabUnSelectedBackGroundColor(context),
-            backgroundColor: UIConfig.desktopSearchTabDividerBackGroundColor(context),
-          ),
-          joinAtFirst: true,
-          joinAtLast: true,
-        );
+        .toList();
+
+    if (ThemeConfig.isApple) {
+      return tabs;
+    }
+
+    return tabs.joinNewElementIndexed(
+      (index) => _SearchTabDivider(
+        hasLeftTab: index >= 0,
+        hasRightTab: index != state.tabLogics.length - 1,
+        leftTabIsSelected: index == state.currentTabIndex,
+        rightTabIsSelected: index == state.currentTabIndex - 1,
+        selectedColor:
+            UIConfig.desktopSearchTabSelectedBackGroundColor(context),
+        unSelectedColor:
+            UIConfig.desktopSearchTabUnSelectedBackGroundColor(context),
+        backgroundColor:
+            UIConfig.desktopSearchTabDividerBackGroundColor(context),
+      ),
+      joinAtFirst: true,
+      joinAtLast: true,
+    );
   }
 
   Widget buildTabView() {
@@ -139,7 +184,9 @@ class DesktopSearchPage extends StatelessWidget with Scroll2TopPageMixin {
         key: state.tabViewKey,
         child: PageView(
           controller: state.pageController,
-          physics: GetPlatform.isDesktop ? const NeverScrollableScrollPhysics() : null,
+          physics: GetPlatform.isDesktop
+              ? const NeverScrollableScrollPhysics()
+              : null,
           onPageChanged: logic.onPageChanged,
           children: state.tabs,
         ),
@@ -192,6 +239,53 @@ class _SearchTabState extends State<_SearchTab> {
 
   @override
   Widget build(BuildContext context) {
+    if (ThemeConfig.isApple) {
+      final colors = Theme.of(context).colorScheme;
+      return GestureDetector(
+        onTap: widget.onTap,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 180),
+          curve: Curves.easeOutCubic,
+          width: UIConfig.desktopSearchTabWidth,
+          margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 2),
+          padding: const EdgeInsets.only(left: 9),
+          decoration: BoxDecoration(
+            color: selected
+                ? colors.primary.withValues(alpha: 0.16)
+                : Colors.transparent,
+            borderRadius: BorderRadius.circular(7),
+            border: Border.all(
+                color: selected
+                    ? colors.primary.withValues(alpha: 0.45)
+                    : Colors.transparent),
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  widget.name,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                      color:
+                          selected ? colors.onSurface : colors.onSurfaceVariant,
+                      letterSpacing: 0.1),
+                ),
+              ),
+              IconButton(
+                onPressed: widget.onDelete,
+                icon: Icon(Icons.close,
+                    color: colors.onSurfaceVariant,
+                    size: UIConfig.desktopSearchTabIconSize),
+                constraints:
+                    const BoxConstraints.tightFor(width: 28, height: 28),
+                padding: EdgeInsets.zero,
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
     return GestureDetector(
       onTap: widget.onTap,
       child: Container(
@@ -205,17 +299,25 @@ class _SearchTabState extends State<_SearchTab> {
               child: Text(
                 widget.name,
                 overflow: TextOverflow.ellipsis,
-                style: TextStyle(color: selected ? widget.selectedTextColor : widget.unSelectedTextColor, letterSpacing: 0.1),
+                style: TextStyle(
+                    color: selected
+                        ? widget.selectedTextColor
+                        : widget.unSelectedTextColor,
+                    letterSpacing: 0.1),
               ).marginOnly(left: 2),
             ),
             IconButton(
               onPressed: widget.onDelete,
               icon: Icon(
                 Icons.clear,
-                color: selected ? widget.selectedTextColor : widget.unSelectedTextColor,
+                color: selected
+                    ? widget.selectedTextColor
+                    : widget.unSelectedTextColor,
                 size: UIConfig.desktopSearchTabIconSize,
               ),
-              constraints: const BoxConstraints.tightFor(width: UIConfig.desktopSearchTabHeight, height: UIConfig.desktopSearchTabHeight),
+              constraints: const BoxConstraints.tightFor(
+                  width: UIConfig.desktopSearchTabHeight,
+                  height: UIConfig.desktopSearchTabHeight),
               padding: EdgeInsets.zero,
             ),
           ],
@@ -263,15 +365,20 @@ class _SearchTabDivider extends StatelessWidget {
               height: UIConfig.desktopSearchTabHeight / 2,
               foregroundDecoration: hasLeftTab
                   ? BoxDecoration(
-                      color: leftTabIsSelected ? selectedColor : unSelectedColor,
-                      borderRadius: const BorderRadius.only(topRight: Radius.circular(UIConfig.desktopSearchTabDividerBorderRadius)),
+                      color:
+                          leftTabIsSelected ? selectedColor : unSelectedColor,
+                      borderRadius: const BorderRadius.only(
+                          topRight: Radius.circular(
+                              UIConfig.desktopSearchTabDividerBorderRadius)),
                     )
                   : null,
             ),
             Container(
               width: UIConfig.desktopSearchTabDividerWidth / 2,
               height: UIConfig.desktopSearchTabHeight / 2,
-              color: leftTabIsSelected || rightTabIsSelected ? selectedColor : unSelectedColor,
+              color: leftTabIsSelected || rightTabIsSelected
+                  ? selectedColor
+                  : unSelectedColor,
               foregroundDecoration: BoxDecoration(
                 color: !hasLeftTab
                     ? backgroundColor
@@ -279,7 +386,9 @@ class _SearchTabDivider extends StatelessWidget {
                         ? unSelectedColor
                         : null,
                 borderRadius: !hasLeftTab || rightTabIsSelected
-                    ? const BorderRadius.only(bottomRight: Radius.circular(UIConfig.desktopSearchTabDividerBorderRadius))
+                    ? const BorderRadius.only(
+                        bottomRight: Radius.circular(
+                            UIConfig.desktopSearchTabDividerBorderRadius))
                     : null,
               ),
             ),
@@ -292,15 +401,20 @@ class _SearchTabDivider extends StatelessWidget {
               height: UIConfig.desktopSearchTabHeight / 2,
               foregroundDecoration: hasRightTab
                   ? BoxDecoration(
-                      color: rightTabIsSelected ? selectedColor : unSelectedColor,
-                      borderRadius: const BorderRadius.only(topLeft: Radius.circular(UIConfig.desktopSearchTabDividerBorderRadius)),
+                      color:
+                          rightTabIsSelected ? selectedColor : unSelectedColor,
+                      borderRadius: const BorderRadius.only(
+                          topLeft: Radius.circular(
+                              UIConfig.desktopSearchTabDividerBorderRadius)),
                     )
                   : null,
             ),
             Container(
               width: UIConfig.desktopSearchTabDividerWidth / 2,
               height: UIConfig.desktopSearchTabHeight / 2,
-              color: leftTabIsSelected || rightTabIsSelected ? selectedColor : unSelectedColor,
+              color: leftTabIsSelected || rightTabIsSelected
+                  ? selectedColor
+                  : unSelectedColor,
               foregroundDecoration: BoxDecoration(
                 color: !hasRightTab
                     ? backgroundColor
@@ -308,7 +422,9 @@ class _SearchTabDivider extends StatelessWidget {
                         ? selectedColor
                         : unSelectedColor,
                 borderRadius: !hasRightTab || leftTabIsSelected
-                    ? const BorderRadius.only(bottomLeft: Radius.circular(UIConfig.desktopSearchTabDividerBorderRadius))
+                    ? const BorderRadius.only(
+                        bottomLeft: Radius.circular(
+                            UIConfig.desktopSearchTabDividerBorderRadius))
                     : null,
               ),
             ),

--- a/lib/src/pages/setting/setting_page.dart
+++ b/lib/src/pages/setting/setting_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:jhentai/src/routes/routes.dart';
+import 'package:jhentai/src/config/theme_config.dart';
 import '../../config/ui_config.dart';
 import '../../setting/user_setting.dart';
 import '../../utils/app_icons.dart';
@@ -16,85 +17,95 @@ class SettingPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        centerTitle: true,
+        centerTitle: !ThemeConfig.isApple,
         title: Text('setting'.tr),
         leading: showMenuButton
-            ? IconButton(icon: Icon(AppIcons.menu, size: 20), onPressed: () => TapMenuButtonNotification().dispatch(context))
+            ? IconButton(
+                icon: Icon(AppIcons.menu, size: 20),
+                onPressed: () => TapMenuButtonNotification().dispatch(context))
             : null,
       ),
       body: Obx(
-        () => ListView(
-          padding: EdgeInsets.only(top: 12, bottom: UIConfig.liquidGlassNavContentInset(context)),
-          children: [
-            ListTile(
-              leading: const Icon(Icons.account_circle),
-              title: Text('account'.tr),
-              onTap: () => toRoute(Routes.settingPrefix + 'account'),
-            ),
-            if (userSetting.hasLoggedIn())
-              ListTile(
-                leading: const Icon(Icons.mood),
-                title: Text('EH'.tr),
-                onTap: () => toRoute(Routes.settingPrefix + 'EH'),
-              ),
-            ListTile(
-              leading: const Icon(Icons.style),
-              title: Text('style'.tr),
-              onTap: () => toRoute(Routes.settingPrefix + 'style'),
-            ),
-            ListTile(
-              leading: const Icon(Icons.local_library),
-              title: Text('read'.tr),
-              onTap: () => toRoute(Routes.settingPrefix + 'read'),
-            ),
-            ListTile(
-              leading: const Icon(Icons.stars),
-              title: Text('preference'.tr),
-              onTap: () => toRoute(Routes.settingPrefix + 'preference'),
-            ),
-            ListTile(
-              leading: const Icon(Icons.wifi),
-              title: Text('network'.tr),
-              onTap: () => toRoute(Routes.settingPrefix + 'network'),
-            ),
-            ListTile(
-              leading: const Icon(Icons.download),
-              title: Text('download'.tr),
-              onTap: () => toRoute(Routes.settingPrefix + 'download'),
-            ),
-            ListTile(
-              leading: const Icon(Icons.electric_bolt),
-              title: Text('performance'.tr),
-              onTap: () => toRoute(Routes.settingPrefix + 'performance'),
-            ),
-            ListTile(
-              leading: const Icon(Icons.mouse),
-              title: Text('mouseWheel'.tr),
-              onTap: () => toRoute(Routes.settingPrefix + 'mouse_wheel'),
-            ),
-            ListTile(
-              leading: const Icon(Icons.settings_suggest),
-              title: Text('advanced'.tr),
-              onTap: () => toRoute(Routes.settingPrefix + 'advanced'),
-            ),
-            // ListTile(
-            //   leading: const Icon(Icons.cloud),
-            //   title: Text('cloud'.tr),
-            //   onTap: () => toRoute(Routes.settingPrefix + 'cloud'),
-            // ),
-            ListTile(
-              leading: const Icon(Icons.security),
-              title: Text('security'.tr),
-              onTap: () => toRoute(Routes.settingPrefix + 'security'),
-            ),
-            ListTile(
-              leading: const Icon(Icons.info),
-              title: Text('about'.tr),
-              onTap: () => toRoute(Routes.settingPrefix + 'about'),
-            ),
-          ],
-        ),
+        () => ThemeConfig.isApple
+            ? _buildAppleSettings(context)
+            : _buildMaterialSettings(context),
       ),
     );
   }
+
+  Widget _buildMaterialSettings(BuildContext context) => ListView(
+        padding: EdgeInsets.only(
+            top: 12, bottom: UIConfig.liquidGlassNavContentInset(context)),
+        children: _settingTiles(appleStyle: false),
+      );
+
+  Widget _buildAppleSettings(BuildContext context) {
+    final tiles = _settingTiles(appleStyle: true);
+    final groups = <List<ListTile>>[
+      tiles.take(userSetting.hasLoggedIn() ? 2 : 1).toList(),
+      tiles.skip(userSetting.hasLoggedIn() ? 2 : 1).take(3).toList(),
+      tiles.skip(userSetting.hasLoggedIn() ? 5 : 4).toList(),
+    ];
+    return ListView.separated(
+      padding: EdgeInsets.fromLTRB(
+          14, 16, 14, 24 + UIConfig.liquidGlassNavContentInset(context)),
+      itemCount: groups.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 16),
+      itemBuilder: (_, index) => DecoratedBox(
+        decoration: BoxDecoration(
+          color: Theme.of(context)
+              .colorScheme
+              .surfaceContainerHighest
+              .withValues(alpha: 0.56),
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(
+              color: Theme.of(context).dividerColor.withValues(alpha: 0.55),
+              width: 0.5),
+        ),
+        child: _buildAppleGroup(context, groups[index]),
+      ),
+    );
+  }
+
+  Widget _buildAppleGroup(BuildContext context, List<ListTile> tiles) => Column(
+        children: [
+          for (var index = 0; index < tiles.length; index++) ...[
+            tiles[index],
+            if (index < tiles.length - 1)
+              Divider(
+                height: 0.5,
+                indent: 56,
+                color: Theme.of(context).dividerColor.withValues(alpha: 0.7),
+              ),
+          ],
+        ],
+      );
+
+  List<ListTile> _settingTiles({required bool appleStyle}) => [
+        _settingTile(Icons.account_circle, 'account', 'account', appleStyle),
+        if (userSetting.hasLoggedIn())
+          _settingTile(Icons.mood, 'EH', 'EH', appleStyle),
+        _settingTile(Icons.style, 'style', 'style', appleStyle),
+        _settingTile(Icons.local_library, 'read', 'read', appleStyle),
+        _settingTile(Icons.stars, 'preference', 'preference', appleStyle),
+        _settingTile(Icons.wifi, 'network', 'network', appleStyle),
+        _settingTile(Icons.download, 'download', 'download', appleStyle),
+        _settingTile(
+            Icons.electric_bolt, 'performance', 'performance', appleStyle),
+        _settingTile(Icons.mouse, 'mouseWheel', 'mouse_wheel', appleStyle),
+        _settingTile(
+            Icons.settings_suggest, 'advanced', 'advanced', appleStyle),
+        _settingTile(Icons.security, 'security', 'security', appleStyle),
+        _settingTile(Icons.info, 'about', 'about', appleStyle),
+      ];
+
+  ListTile _settingTile(
+          IconData icon, String label, String route, bool appleStyle) =>
+      ListTile(
+        leading: Icon(icon),
+        title: Text(label.tr),
+        minVerticalPadding: appleStyle ? 10 : null,
+        trailing: appleStyle ? const Icon(Icons.chevron_right, size: 19) : null,
+        onTap: () => toRoute(Routes.settingPrefix + route),
+      );
 }

--- a/lib/src/pages/setting/setting_page.dart
+++ b/lib/src/pages/setting/setting_page.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:jhentai/src/routes/routes.dart';
+import '../../config/ui_config.dart';
 import '../../setting/user_setting.dart';
+import '../../utils/app_icons.dart';
 import '../../utils/route_util.dart';
 import '../layout/mobile_v2/notification/tap_menu_button_notification.dart';
 
@@ -17,12 +19,12 @@ class SettingPage extends StatelessWidget {
         centerTitle: true,
         title: Text('setting'.tr),
         leading: showMenuButton
-            ? IconButton(icon: Icon(Icons.menu, size: 20), onPressed: () => TapMenuButtonNotification().dispatch(context))
+            ? IconButton(icon: Icon(AppIcons.menu, size: 20), onPressed: () => TapMenuButtonNotification().dispatch(context))
             : null,
       ),
       body: Obx(
         () => ListView(
-          padding: const EdgeInsets.only(top: 12),
+          padding: EdgeInsets.only(top: 12, bottom: UIConfig.liquidGlassNavContentInset(context)),
           children: [
             ListTile(
               leading: const Icon(Icons.account_circle),

--- a/lib/src/pages/setting/style/setting_style_page.dart
+++ b/lib/src/pages/setting/style/setting_style_page.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:jhentai/src/config/theme_config.dart';
 import 'package:jhentai/src/config/ui_config.dart';
 import 'package:jhentai/src/extension/widget_extension.dart';
 import 'package:jhentai/src/setting/style_setting.dart';
+import 'package:jhentai/src/utils/app_icons.dart';
 
 import '../../../model/jh_layout.dart';
 import '../../../routes/routes.dart';
@@ -53,9 +55,16 @@ class SettingStylePage extends StatelessWidget {
   }
 
   Widget _buildThemeColor() {
+    if (ThemeConfig.isApple) {
+      return ListTile(
+        title: Text('themeColor'.tr),
+        subtitle: Text('themeColorFixedOnApple'.tr),
+        enabled: false,
+      );
+    }
     return ListTile(
       title: Text('themeColor'.tr),
-      trailing: const Icon(Icons.keyboard_arrow_right),
+      trailing: Icon(AppIcons.chevronRight),
       onTap: () => toRoute(Routes.themeColor),
     );
   }

--- a/lib/src/pages/setting/style/setting_style_page.dart
+++ b/lib/src/pages/setting/style/setting_style_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:jhentai/src/config/theme_config.dart';
 import 'package:jhentai/src/config/ui_config.dart';
+import 'package:jhentai/src/config/theme_config.dart';
 import 'package:jhentai/src/extension/widget_extension.dart';
 import 'package:jhentai/src/setting/style_setting.dart';
 import 'package:jhentai/src/utils/app_icons.dart';
@@ -23,13 +23,16 @@ class SettingStylePage extends StatelessWidget {
           children: [
             _buildBrightness(),
             _buildThemeColor(),
+            if (ThemeConfig.isApplePlatform) _buildAppleVisualStyle(),
             _buildListMode(),
-            if (styleSetting.isInWaterFlowListMode) _buildCrossAxisCountInWaterFallFlow().fadeIn(),
+            if (styleSetting.isInWaterFlowListMode)
+              _buildCrossAxisCountInWaterFallFlow().fadeIn(),
             _buildPageListMode(),
             _buildCrossAxisCountInGridDownloadPageForGroup(),
             _buildCrossAxisCountInGridDownloadPageForGallery(),
             _buildCrossAxisCountInDetailPage(),
-            if (!styleSetting.isInWaterFlowListMode) _buildMoveCover2RightSide().fadeIn(),
+            if (!styleSetting.isInWaterFlowListMode)
+              _buildMoveCover2RightSide().fadeIn(),
             _buildLayout(context),
           ],
         ).withListTileTheme(context),
@@ -44,28 +47,36 @@ class SettingStylePage extends StatelessWidget {
         value: styleSetting.themeMode.value,
         elevation: 4,
         alignment: AlignmentDirectional.centerEnd,
-        onChanged: (ThemeMode? newValue) => styleSetting.saveThemeMode(newValue!),
+        onChanged: (ThemeMode? newValue) =>
+            styleSetting.saveThemeMode(newValue!),
         items: [
           DropdownMenuItem(child: Text('light'.tr), value: ThemeMode.light),
           DropdownMenuItem(child: Text('dark'.tr), value: ThemeMode.dark),
-          DropdownMenuItem(child: Text('followSystem'.tr), value: ThemeMode.system),
+          DropdownMenuItem(
+              child: Text('followSystem'.tr), value: ThemeMode.system),
         ],
       ),
     );
   }
 
   Widget _buildThemeColor() {
-    if (ThemeConfig.isApple) {
-      return ListTile(
-        title: Text('themeColor'.tr),
-        subtitle: Text('themeColorFixedOnApple'.tr),
-        enabled: false,
-      );
-    }
     return ListTile(
       title: Text('themeColor'.tr),
       trailing: Icon(AppIcons.chevronRight),
       onTap: () => toRoute(Routes.themeColor),
+    );
+  }
+
+  Widget _buildAppleVisualStyle() {
+    return ListTile(
+      title: Text('appleVisualStyle'.tr),
+      subtitle: Text('appleVisualStyleHint'.tr),
+      trailing: Switch(
+        value: styleSetting.appleVisualStyle.value,
+        onChanged: styleSetting.saveAppleVisualStyle,
+      ),
+      onTap: () => styleSetting
+          .saveAppleVisualStyle(!styleSetting.appleVisualStyle.value),
     );
   }
 
@@ -79,12 +90,23 @@ class SettingStylePage extends StatelessWidget {
         onChanged: (ListMode? newValue) => styleSetting.saveListMode(newValue!),
         items: [
           DropdownMenuItem(child: Text('flat'.tr), value: ListMode.flat),
-          DropdownMenuItem(child: Text('flatWithoutTags'.tr), value: ListMode.flatWithoutTags),
-          DropdownMenuItem(child: Text('listWithTags'.tr), value: ListMode.listWithTags),
-          DropdownMenuItem(child: Text('listWithoutTags'.tr), value: ListMode.listWithoutTags),
-          DropdownMenuItem(child: Text('waterfallFlowSmall'.tr), value: ListMode.waterfallFlowSmall),
-          DropdownMenuItem(child: Text('waterfallFlowMedium'.tr), value: ListMode.waterfallFlowMedium),
-          DropdownMenuItem(child: Text('waterfallFlowBig'.tr), value: ListMode.waterfallFlowBig),
+          DropdownMenuItem(
+              child: Text('flatWithoutTags'.tr),
+              value: ListMode.flatWithoutTags),
+          DropdownMenuItem(
+              child: Text('listWithTags'.tr), value: ListMode.listWithTags),
+          DropdownMenuItem(
+              child: Text('listWithoutTags'.tr),
+              value: ListMode.listWithoutTags),
+          DropdownMenuItem(
+              child: Text('waterfallFlowSmall'.tr),
+              value: ListMode.waterfallFlowSmall),
+          DropdownMenuItem(
+              child: Text('waterfallFlowMedium'.tr),
+              value: ListMode.waterfallFlowMedium),
+          DropdownMenuItem(
+              child: Text('waterfallFlowBig'.tr),
+              value: ListMode.waterfallFlowBig),
         ],
       ),
     );
@@ -190,16 +212,25 @@ class SettingStylePage extends StatelessWidget {
   Widget _buildLayout(BuildContext context) {
     return ListTile(
       title: Text('layoutMode'.tr),
-      subtitle: Text(JHLayout.allLayouts.firstWhere((e) => e.mode == styleSetting.layout.value).desc),
+      subtitle: Text(JHLayout.allLayouts
+          .firstWhere((e) => e.mode == styleSetting.layout.value)
+          .desc),
       trailing: DropdownButton<LayoutMode>(
         value: styleSetting.actualLayout,
         elevation: 4,
         alignment: AlignmentDirectional.centerEnd,
-        onChanged: (LayoutMode? newValue) => styleSetting.saveLayoutMode(newValue!),
+        onChanged: (LayoutMode? newValue) =>
+            styleSetting.saveLayoutMode(newValue!),
         items: JHLayout.allLayouts
             .map((e) => DropdownMenuItem(
                   enabled: e.isSupported(),
-                  child: Text(e.name, style: e.isSupported() ? null : TextStyle(color: UIConfig.settingPageLayoutSelectorUnSupportColor(context))),
+                  child: Text(e.name,
+                      style: e.isSupported()
+                          ? null
+                          : TextStyle(
+                              color: UIConfig
+                                  .settingPageLayoutSelectorUnSupportColor(
+                                      context))),
                   value: e.mode,
                 ))
             .toList(),

--- a/lib/src/service/windows_service.dart
+++ b/lib/src/service/windows_service.dart
@@ -7,6 +7,7 @@ import 'package:jhentai/src/enum/config_enum.dart';
 import 'package:jhentai/src/service/local_config_service.dart';
 import 'package:jhentai/src/utils/screen_size_util.dart';
 import 'package:throttling/throttling.dart';
+import 'package:macos_window_utils/macos_window_utils.dart';
 import 'package:window_manager/window_manager.dart';
 
 import '../setting/preference_setting.dart';
@@ -57,6 +58,12 @@ class WindowService with JHLifeCircleBeanErrorCatch implements JHLifeCircleBean 
       windowManager.waitUntilReadyToShow(windowOptions, () async {
         await windowManager.show();
         await windowManager.focus();
+        if (GetPlatform.isMacOS) {
+          /// Let the app draw a theme-colored strip under the native traffic
+          /// lights (native translucent sidebar + frosted window).
+          await WindowManipulator.makeTitlebarTransparent();
+          await WindowManipulator.enableFullSizeContentView();
+        }
         if (preferenceSetting.launchInFullScreen.isTrue) {
           await windowManager.setFullScreen(true);
         }

--- a/lib/src/service/windows_service.dart
+++ b/lib/src/service/windows_service.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:jhentai/src/enum/config_enum.dart';
+import 'package:jhentai/src/config/theme_config.dart';
 import 'package:jhentai/src/service/local_config_service.dart';
 import 'package:jhentai/src/utils/screen_size_util.dart';
 import 'package:throttling/throttling.dart';
@@ -11,13 +12,16 @@ import 'package:macos_window_utils/macos_window_utils.dart';
 import 'package:window_manager/window_manager.dart';
 
 import '../setting/preference_setting.dart';
+import '../setting/style_setting.dart';
 import 'app_update_service.dart';
 import 'jh_service.dart';
 import 'log.dart';
 
 WindowService windowService = WindowService();
 
-class WindowService with JHLifeCircleBeanErrorCatch implements JHLifeCircleBean {
+class WindowService
+    with JHLifeCircleBeanErrorCatch
+    implements JHLifeCircleBean {
   bool windowManagerInited = false;
 
   double windowWidth = 1280;
@@ -27,20 +31,38 @@ class WindowService with JHLifeCircleBeanErrorCatch implements JHLifeCircleBean 
 
   double leftColumnWidthRatio = 1 - 0.618;
 
-  final Debouncing windowResizedDebouncing = Debouncing(duration: const Duration(milliseconds: 300));
-  final Debouncing columnResizedDebouncing = Debouncing(duration: const Duration(milliseconds: 300));
+  final Debouncing windowResizedDebouncing =
+      Debouncing(duration: const Duration(milliseconds: 300));
+  final Debouncing columnResizedDebouncing =
+      Debouncing(duration: const Duration(milliseconds: 300));
 
   @override
-  List<JHLifeCircleBean> get initDependencies => super.initDependencies..addAll([localConfigService, preferenceSetting, appUpdateService]);
+  List<JHLifeCircleBean> get initDependencies => super.initDependencies
+    ..addAll([
+      localConfigService,
+      preferenceSetting,
+      styleSetting,
+      appUpdateService
+    ]);
 
   @override
   Future<void> doInitBean() async {
-    windowWidth = await localConfigService.read(configKey: ConfigEnum.windowWidth).then((value) => value != null ? double.parse(value) : windowWidth);
-    windowHeight = await localConfigService.read(configKey: ConfigEnum.windowHeight).then((value) => value != null ? double.parse(value) : windowHeight);
-    isMaximized = await localConfigService.read(configKey: ConfigEnum.windowMaximize).then((value) => value != null ? value == 'true' : isMaximized);
-    isFullScreen = await localConfigService.read(configKey: ConfigEnum.windowFullScreen).then((value) => value != null ? value == 'true' : isFullScreen);
-    leftColumnWidthRatio =
-        await localConfigService.read(configKey: ConfigEnum.leftColumnWidthRatio).then((value) => value != null ? double.parse(value) : leftColumnWidthRatio);
+    windowWidth = await localConfigService
+        .read(configKey: ConfigEnum.windowWidth)
+        .then((value) => value != null ? double.parse(value) : windowWidth);
+    windowHeight = await localConfigService
+        .read(configKey: ConfigEnum.windowHeight)
+        .then((value) => value != null ? double.parse(value) : windowHeight);
+    isMaximized = await localConfigService
+        .read(configKey: ConfigEnum.windowMaximize)
+        .then((value) => value != null ? value == 'true' : isMaximized);
+    isFullScreen = await localConfigService
+        .read(configKey: ConfigEnum.windowFullScreen)
+        .then((value) => value != null ? value == 'true' : isFullScreen);
+    leftColumnWidthRatio = await localConfigService
+        .read(configKey: ConfigEnum.leftColumnWidthRatio)
+        .then((value) =>
+            value != null ? double.parse(value) : leftColumnWidthRatio);
     leftColumnWidthRatio = max(0.01, leftColumnWidthRatio);
 
     if (GetPlatform.isDesktop) {
@@ -52,15 +74,17 @@ class WindowService with JHLifeCircleBeanErrorCatch implements JHLifeCircleBean 
         backgroundColor: Colors.transparent,
         skipTaskbar: false,
         title: 'JHenTai',
-        titleBarStyle: GetPlatform.isWindows ? TitleBarStyle.hidden : TitleBarStyle.normal,
+        titleBarStyle: GetPlatform.isWindows || ThemeConfig.isApple
+            ? TitleBarStyle.hidden
+            : TitleBarStyle.normal,
       );
 
       windowManager.waitUntilReadyToShow(windowOptions, () async {
         await windowManager.show();
         await windowManager.focus();
-        if (GetPlatform.isMacOS) {
-          /// Let the app draw a theme-colored strip under the native traffic
-          /// lights (native translucent sidebar + frosted window).
+        if (GetPlatform.isMacOS && ThemeConfig.isApple) {
+          /// Let the sidebar's native material extend beneath the traffic
+          /// lights while the Flutter content reaches the top edge.
           await WindowManipulator.makeTitlebarTransparent();
           await WindowManipulator.enableFullSizeContentView();
         }
@@ -76,7 +100,25 @@ class WindowService with JHLifeCircleBeanErrorCatch implements JHLifeCircleBean 
   }
 
   @override
-  Future<void> doAfterBeanReady() async {}
+  Future<void> doAfterBeanReady() async {
+    ever(styleSetting.appleVisualStyle,
+        (enabled) => applyAppleVisualStyle(enabled));
+  }
+
+  Future<void> applyAppleVisualStyle(bool enabled) async {
+    if (!GetPlatform.isMacOS || !windowManagerInited) {
+      return;
+    }
+    await windowManager.setTitleBarStyle(
+        enabled ? TitleBarStyle.hidden : TitleBarStyle.normal);
+    if (enabled) {
+      await WindowManipulator.makeTitlebarTransparent();
+      await WindowManipulator.enableFullSizeContentView();
+    } else {
+      await WindowManipulator.makeTitlebarOpaque();
+      await WindowManipulator.disableFullSizeContentView();
+    }
+  }
 
   void handleDoubleColumnResized(UnmodifiableListView<double> ratios) {
     if (leftColumnWidthRatio == ratios[0]) {
@@ -87,7 +129,9 @@ class WindowService with JHLifeCircleBeanErrorCatch implements JHLifeCircleBean 
       leftColumnWidthRatio = max(0.01, ratios[0]);
 
       log.info('Resize left column ratio to: $leftColumnWidthRatio');
-      localConfigService.write(configKey: ConfigEnum.leftColumnWidthRatio, value: leftColumnWidthRatio.toString());
+      localConfigService.write(
+          configKey: ConfigEnum.leftColumnWidthRatio,
+          value: leftColumnWidthRatio.toString());
     });
   }
 
@@ -98,8 +142,10 @@ class WindowService with JHLifeCircleBeanErrorCatch implements JHLifeCircleBean 
 
       log.info('Resize window to: $windowWidth x $windowHeight');
 
-      localConfigService.write(configKey: ConfigEnum.windowWidth, value: windowWidth.toString());
-      localConfigService.write(configKey: ConfigEnum.windowHeight, value: windowHeight.toString());
+      localConfigService.write(
+          configKey: ConfigEnum.windowWidth, value: windowWidth.toString());
+      localConfigService.write(
+          configKey: ConfigEnum.windowHeight, value: windowHeight.toString());
     });
   }
 
@@ -107,13 +153,15 @@ class WindowService with JHLifeCircleBeanErrorCatch implements JHLifeCircleBean 
     log.info(isMaximized ? 'Maximized window' : 'Restored window');
 
     this.isMaximized = isMaximized;
-    return localConfigService.write(configKey: ConfigEnum.windowMaximize, value: isMaximized.toString());
+    return localConfigService.write(
+        configKey: ConfigEnum.windowMaximize, value: isMaximized.toString());
   }
 
   Future<int> saveFullScreen(bool isFullScreen) {
     log.info(isFullScreen ? 'Enter full screen' : 'Leave full screen');
 
     this.isFullScreen = isFullScreen;
-    return localConfigService.write(configKey: ConfigEnum.windowFullScreen, value: isFullScreen.toString());
+    return localConfigService.write(
+        configKey: ConfigEnum.windowFullScreen, value: isFullScreen.toString());
   }
 }

--- a/lib/src/setting/style_setting.dart
+++ b/lib/src/setting/style_setting.dart
@@ -4,6 +4,7 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:jhentai/src/config/ui_config.dart';
+import 'package:jhentai/src/config/theme_config.dart';
 import 'package:jhentai/src/enum/config_enum.dart';
 import 'package:jhentai/src/service/jh_service.dart';
 import 'package:jhentai/src/service/log.dart';
@@ -12,7 +13,9 @@ import '../model/jh_layout.dart';
 
 StyleSetting styleSetting = StyleSetting();
 
-class StyleSetting with JHLifeCircleBeanWithConfigStorage implements JHLifeCircleBean {
+class StyleSetting
+    with JHLifeCircleBeanWithConfigStorage
+    implements JHLifeCircleBean {
   Rx<ThemeMode> themeMode = ThemeMode.system.obs;
   Rx<Color> lightThemeColor = UIConfig.defaultLightThemeColor.obs;
   Rx<Color> darkThemeColor = UIConfig.defaultDarkThemeColor.obs;
@@ -23,14 +26,20 @@ class StyleSetting with JHLifeCircleBeanWithConfigStorage implements JHLifeCircl
   RxnInt crossAxisCountInDetailPage = RxnInt(null);
   RxMap<String, ListMode> pageListMode = <String, ListMode>{}.obs;
   RxBool moveCover2RightSide = false.obs;
-  Rx<LayoutMode> layout = PlatformDispatcher.instance.views.first.physicalSize.width / PlatformDispatcher.instance.views.first.devicePixelRatio < 600
-      ? LayoutMode.mobileV2.obs
-      : GetPlatform.isDesktop
-          ? LayoutMode.desktop.obs
-          : LayoutMode.tabletV2.obs;
+  RxBool appleVisualStyle = false.obs;
+  Rx<LayoutMode> layout =
+      PlatformDispatcher.instance.views.first.physicalSize.width /
+                  PlatformDispatcher.instance.views.first.devicePixelRatio <
+              600
+          ? LayoutMode.mobileV2.obs
+          : GetPlatform.isDesktop
+              ? LayoutMode.desktop.obs
+              : LayoutMode.tabletV2.obs;
 
   bool get isInWaterFlowListMode =>
-      listMode.value == ListMode.waterfallFlowBig || listMode.value == ListMode.waterfallFlowSmall || listMode.value == ListMode.waterfallFlowMedium;
+      listMode.value == ListMode.waterfallFlowBig ||
+      listMode.value == ListMode.waterfallFlowSmall ||
+      listMode.value == ListMode.waterfallFlowMedium;
 
   Brightness currentBrightness() => themeMode.value == ThemeMode.system
       ? PlatformDispatcher.instance.platformBrightness
@@ -39,19 +48,27 @@ class StyleSetting with JHLifeCircleBeanWithConfigStorage implements JHLifeCircl
           : Brightness.dark;
 
   /// If the current window width is too small, App will degrade to mobile mode. Use [actualLayout] to indicate actual layout.
-  LayoutMode actualLayout = PlatformDispatcher.instance.views.first.physicalSize.width / PlatformDispatcher.instance.views.first.devicePixelRatio < 600
-      ? LayoutMode.mobileV2
-      : GetPlatform.isDesktop
-          ? LayoutMode.desktop
-          : LayoutMode.tabletV2;
+  LayoutMode actualLayout =
+      PlatformDispatcher.instance.views.first.physicalSize.width /
+                  PlatformDispatcher.instance.views.first.devicePixelRatio <
+              600
+          ? LayoutMode.mobileV2
+          : GetPlatform.isDesktop
+              ? LayoutMode.desktop
+              : LayoutMode.tabletV2;
 
-  bool get isInMobileLayout => actualLayout == LayoutMode.mobileV2 || actualLayout == LayoutMode.mobile;
+  bool get isInMobileLayout =>
+      actualLayout == LayoutMode.mobileV2 || actualLayout == LayoutMode.mobile;
 
-  bool get isInTabletLayout => actualLayout == LayoutMode.tabletV2 || actualLayout == LayoutMode.tablet;
+  bool get isInTabletLayout =>
+      actualLayout == LayoutMode.tabletV2 || actualLayout == LayoutMode.tablet;
 
-  bool get isInV1Layout => actualLayout == LayoutMode.mobile || actualLayout == LayoutMode.tablet;
+  bool get isInV1Layout =>
+      actualLayout == LayoutMode.mobile || actualLayout == LayoutMode.tablet;
 
-  bool get isInV2Layout => actualLayout == LayoutMode.mobileV2 || actualLayout == LayoutMode.tabletV2;
+  bool get isInV2Layout =>
+      actualLayout == LayoutMode.mobileV2 ||
+      actualLayout == LayoutMode.tabletV2;
 
   bool get isInDesktopLayout => actualLayout == LayoutMode.desktop;
 
@@ -63,20 +80,32 @@ class StyleSetting with JHLifeCircleBeanWithConfigStorage implements JHLifeCircl
     Map map = jsonDecode(configString);
 
     themeMode.value = ThemeMode.values[map['themeMode']];
-    lightThemeColor.value = Color(map['lightThemeColor'] ?? lightThemeColor.value.toARGB32());
-    darkThemeColor.value = Color(map['darkThemeColor'] ?? darkThemeColor.value.toARGB32());
+    lightThemeColor.value =
+        Color(map['lightThemeColor'] ?? lightThemeColor.value.toARGB32());
+    darkThemeColor.value =
+        Color(map['darkThemeColor'] ?? darkThemeColor.value.toARGB32());
     listMode.value = ListMode.values[map['listMode']];
     crossAxisCountInWaterFallFlow.value = map['crossAxisCountInWaterFallFlow'];
-    crossAxisCountInGridDownloadPageForGroup.value = map['crossAxisCountInGridDownloadPageForGroup'];
-    crossAxisCountInGridDownloadPageForGallery.value = map['crossAxisCountInGridDownloadPageForGallery'];
+    crossAxisCountInGridDownloadPageForGroup.value =
+        map['crossAxisCountInGridDownloadPageForGroup'];
+    crossAxisCountInGridDownloadPageForGallery.value =
+        map['crossAxisCountInGridDownloadPageForGallery'];
     crossAxisCountInDetailPage.value = map['crossAxisCountInDetailPage'];
-    pageListMode.value = Map.from(map['pageListMode']?.map((route, listModeIndex) => MapEntry(route, ListMode.values[listModeIndex])) ?? {});
-    moveCover2RightSide.value = map['moveCover2RightSide'] ?? moveCover2RightSide.value;
+    pageListMode.value = Map.from(map['pageListMode']?.map(
+            (route, listModeIndex) =>
+                MapEntry(route, ListMode.values[listModeIndex])) ??
+        {});
+    moveCover2RightSide.value =
+        map['moveCover2RightSide'] ?? moveCover2RightSide.value;
+    appleVisualStyle.value = map['appleVisualStyle'] ?? false;
+    ThemeConfig.appleVisualStyleEnabled = appleVisualStyle.value;
     layout.value = LayoutMode.values[map['layout'] ?? layout.value.index];
 
     /// old layout has been removed in v5.0.0
     if (isInV1Layout) {
-      layout = PlatformDispatcher.instance.views.first.physicalSize.width / PlatformDispatcher.instance.views.first.devicePixelRatio < 600
+      layout = PlatformDispatcher.instance.views.first.physicalSize.width /
+                  PlatformDispatcher.instance.views.first.devicePixelRatio <
+              600
           ? LayoutMode.mobileV2.obs
           : GetPlatform.isDesktop
               ? LayoutMode.desktop.obs
@@ -93,11 +122,15 @@ class StyleSetting with JHLifeCircleBeanWithConfigStorage implements JHLifeCircl
       'darkThemeColor': darkThemeColor.value.toARGB32(),
       'listMode': listMode.value.index,
       'crossAxisCountInWaterFallFlow': crossAxisCountInWaterFallFlow.value,
-      'crossAxisCountInGridDownloadPageForGroup': crossAxisCountInGridDownloadPageForGroup.value,
-      'crossAxisCountInGridDownloadPageForGallery': crossAxisCountInGridDownloadPageForGallery.value,
+      'crossAxisCountInGridDownloadPageForGroup':
+          crossAxisCountInGridDownloadPageForGroup.value,
+      'crossAxisCountInGridDownloadPageForGallery':
+          crossAxisCountInGridDownloadPageForGallery.value,
       'crossAxisCountInDetailPage': crossAxisCountInDetailPage.value,
-      'pageListMode': pageListMode.map((route, listMode) => MapEntry(route, listMode.index)),
+      'pageListMode': pageListMode
+          .map((route, listMode) => MapEntry(route, listMode.index)),
       'moveCover2RightSide': moveCover2RightSide.value,
+      'appleVisualStyle': appleVisualStyle.value,
       'layout': layout.value.index,
     });
   }
@@ -109,6 +142,14 @@ class StyleSetting with JHLifeCircleBeanWithConfigStorage implements JHLifeCircl
   void doAfterBeanReady() {
     ever(themeMode, (_) {
       Get.changeThemeMode(themeMode.value);
+    });
+    ever(appleVisualStyle, (enabled) async {
+      ThemeConfig.appleVisualStyleEnabled = enabled;
+      Get.rootController.theme =
+          ThemeConfig.theme(lightThemeColor.value, Brightness.light);
+      Get.rootController.darkTheme =
+          ThemeConfig.theme(darkThemeColor.value, Brightness.dark);
+      await Get.forceAppUpdate();
     });
   }
 
@@ -136,25 +177,34 @@ class StyleSetting with JHLifeCircleBeanWithConfigStorage implements JHLifeCircl
     await saveBeanConfig();
   }
 
-  Future<void> saveCrossAxisCountInWaterFallFlow(int? crossAxisCountInWaterFallFlow) async {
-    log.debug('saveCrossAxisCountInWaterFallFlow:$crossAxisCountInWaterFallFlow');
+  Future<void> saveCrossAxisCountInWaterFallFlow(
+      int? crossAxisCountInWaterFallFlow) async {
+    log.debug(
+        'saveCrossAxisCountInWaterFallFlow:$crossAxisCountInWaterFallFlow');
     this.crossAxisCountInWaterFallFlow.value = crossAxisCountInWaterFallFlow;
     await saveBeanConfig();
   }
 
-  Future<void> saveCrossAxisCountInGridDownloadPageForGroup(int? crossAxisCountInGridDownloadPageForGroup) async {
-    log.debug('saveCrossAxisCountInGridDownloadPageForGroup:$crossAxisCountInGridDownloadPageForGroup');
-    this.crossAxisCountInGridDownloadPageForGroup.value = crossAxisCountInGridDownloadPageForGroup;
+  Future<void> saveCrossAxisCountInGridDownloadPageForGroup(
+      int? crossAxisCountInGridDownloadPageForGroup) async {
+    log.debug(
+        'saveCrossAxisCountInGridDownloadPageForGroup:$crossAxisCountInGridDownloadPageForGroup');
+    this.crossAxisCountInGridDownloadPageForGroup.value =
+        crossAxisCountInGridDownloadPageForGroup;
     await saveBeanConfig();
   }
 
-  Future<void> saveCrossAxisCountInGridDownloadPageForGallery(int? crossAxisCountInGridDownloadPageForGallery) async {
-    log.debug('saveCrossAxisCountInGridDownloadPageForGallery:$crossAxisCountInGridDownloadPageForGallery');
-    this.crossAxisCountInGridDownloadPageForGallery.value = crossAxisCountInGridDownloadPageForGallery;
+  Future<void> saveCrossAxisCountInGridDownloadPageForGallery(
+      int? crossAxisCountInGridDownloadPageForGallery) async {
+    log.debug(
+        'saveCrossAxisCountInGridDownloadPageForGallery:$crossAxisCountInGridDownloadPageForGallery');
+    this.crossAxisCountInGridDownloadPageForGallery.value =
+        crossAxisCountInGridDownloadPageForGallery;
     await saveBeanConfig();
   }
 
-  Future<void> saveCrossAxisCountInDetailPage(int? crossAxisCountInDetailPage) async {
+  Future<void> saveCrossAxisCountInDetailPage(
+      int? crossAxisCountInDetailPage) async {
     log.debug('saveCrossAxisCountInDetailPage:$crossAxisCountInDetailPage');
     this.crossAxisCountInDetailPage.value = crossAxisCountInDetailPage;
     await saveBeanConfig();
@@ -173,6 +223,12 @@ class StyleSetting with JHLifeCircleBeanWithConfigStorage implements JHLifeCircl
   Future<void> saveMoveCover2RightSide(bool moveCover2RightSide) async {
     log.debug('saveMoveCover2RightSide:$moveCover2RightSide');
     this.moveCover2RightSide.value = moveCover2RightSide;
+    await saveBeanConfig();
+  }
+
+  Future<void> saveAppleVisualStyle(bool enabled) async {
+    log.debug('saveAppleVisualStyle:$enabled');
+    appleVisualStyle.value = enabled;
     await saveBeanConfig();
   }
 

--- a/lib/src/utils/app_icons.dart
+++ b/lib/src/utils/app_icons.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+/// Platform-aware chrome icons: SF Symbols (`CupertinoIcons`) on iOS/macOS,
+/// Material icons elsewhere. `xxxFill` is the selected/filled variant, `xxx`
+/// the unselected/outline variant (matching Material's filled/outlined pair).
+class AppIcons {
+  static bool get isApple => GetPlatform.isIOS || GetPlatform.isMacOS;
+
+  static IconData get home => isApple ? CupertinoIcons.house : Icons.home_outlined;
+  static IconData get homeFill => isApple ? CupertinoIcons.house_fill : Icons.home;
+  static IconData get search => isApple ? CupertinoIcons.search : Icons.search;
+  static IconData get popular => isApple ? CupertinoIcons.flame : Icons.whatshot_outlined;
+  static IconData get popularFill => isApple ? CupertinoIcons.flame_fill : Icons.whatshot;
+  static IconData get ranklist => isApple ? CupertinoIcons.chart_bar : Icons.bar_chart_outlined;
+  static IconData get ranklistFill => isApple ? CupertinoIcons.chart_bar_fill : Icons.bar_chart_rounded;
+  static IconData get favorite => isApple ? CupertinoIcons.heart : Icons.favorite_outline;
+  static IconData get favoriteFill => isApple ? CupertinoIcons.heart_fill : Icons.favorite;
+  static IconData get watched => isApple ? CupertinoIcons.eye : Icons.visibility_outlined;
+  static IconData get watchedFill => isApple ? CupertinoIcons.eye_fill : Icons.visibility;
+  static IconData get history => isApple ? CupertinoIcons.clock : Icons.history_outlined;
+  static IconData get historyFill => isApple ? CupertinoIcons.clock_fill : Icons.history;
+  static IconData get download => isApple ? CupertinoIcons.square_arrow_down : Icons.download_outlined;
+  static IconData get downloadFill => isApple ? CupertinoIcons.square_arrow_down_fill : Icons.download;
+  static IconData get settings => isApple ? CupertinoIcons.gear : Icons.settings_outlined;
+  static IconData get settingsFill => isApple ? CupertinoIcons.gear_solid : Icons.settings;
+  static IconData get menu => isApple ? CupertinoIcons.bars : Icons.menu;
+  static IconData get jump => isApple ? CupertinoIcons.paperplane : Icons.send;
+  static IconData get filter => isApple ? CupertinoIcons.line_horizontal_3_decrease : Icons.filter_alt_outlined;
+  static IconData get chevronRight => isApple ? CupertinoIcons.chevron_right : Icons.keyboard_arrow_right;
+}

--- a/lib/src/utils/screen_size_util.dart
+++ b/lib/src/utils/screen_size_util.dart
@@ -1,13 +1,18 @@
 import 'package:get/get.dart';
 import 'package:jhentai/src/config/ui_config.dart';
+import 'package:jhentai/src/config/theme_config.dart';
 import 'package:jhentai/src/setting/style_setting.dart';
 
 double get fullScreenWidth => Get.width;
+
+double get _desktopLeftRailWidth => GetPlatform.isMacOS && ThemeConfig.isApple
+    ? UIConfig.desktopMacOSLeftTabBarWidth
+    : UIConfig.desktopLeftTabBarWidth;
 
 double get screenWidth => styleSetting.isInMobileLayout
     ? Get.width
     : styleSetting.isInTabletLayout
         ? Get.width / 2
-        : (Get.width - UIConfig.desktopLeftTabBarWidth) / 2;
+        : (Get.width - _desktopLeftRailWidth) / 2;
 
 double get screenHeight => Get.height;

--- a/lib/src/widget/eh_gallery_collection.dart
+++ b/lib/src/widget/eh_gallery_collection.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_list_view/flutter_list_view.dart';
-import 'package:get/get.dart';
+import 'package:jhentai/src/config/theme_config.dart';
 import 'package:jhentai/src/config/ui_config.dart';
 import 'package:jhentai/src/service/archive_download_service.dart';
 import 'package:jhentai/src/service/gallery_download_service.dart';
@@ -31,25 +31,42 @@ Widget EHGalleryCollection({
       key: key,
       delegate: FlutterListViewDelegate(
         (_, int index) {
-          if (index == gallerys.length - 1 && loadingState == LoadingState.idle && handleLoadMore != null) {
-            SchedulerBinding.instance.addPostFrameCallback((_) => handleLoadMore());
+          if (index == gallerys.length - 1 &&
+              loadingState == LoadingState.idle &&
+              handleLoadMore != null) {
+            SchedulerBinding.instance
+                .addPostFrameCallback((_) => handleLoadMore());
           }
           return Container(
-            decoration: listMode == ListMode.flat || listMode == ListMode.flatWithoutTags
+            decoration: listMode == ListMode.flat ||
+                    listMode == ListMode.flatWithoutTags
                 ? BoxDecoration(
                     color: UIConfig.backGroundColor(context),
-                    border: Border(bottom: BorderSide(width: 0.5, color: Theme.of(context).dividerColor)),
+                    border: Border(
+                        bottom: BorderSide(
+                            width: 0.5, color: Theme.of(context).dividerColor)),
                   )
                 : null,
-            padding: const EdgeInsets.symmetric(vertical: 5, horizontal: 10),
+            padding: ThemeConfig.isApple
+                ? EdgeInsets.zero
+                : const EdgeInsets.symmetric(vertical: 5, horizontal: 10),
             child: EHGalleryListCard(
               gallery: gallerys[index],
-              downloaded: galleryDownloadService.containGallery(gallerys[index].gid) || archiveDownloadService.containArchive(gallerys[index].gid),
+              downloaded: galleryDownloadService
+                      .containGallery(gallerys[index].gid) ||
+                  archiveDownloadService.containArchive(gallerys[index].gid),
               listMode: listMode,
               handleTapCard: (gallery) => handleTapCard(gallery),
-              handleLongPressCard: handleLongPressCard == null ? null : (gallery, position) => handleLongPressCard(gallery, position),
-              handleSecondaryTapCard: handleSecondaryTapCard == null ? null : (gallery, position) => handleSecondaryTapCard(gallery, position),
-              withTags: listMode == ListMode.listWithTags || listMode == ListMode.flat,
+              handleLongPressCard: handleLongPressCard == null
+                  ? null
+                  : (gallery, position) =>
+                      handleLongPressCard(gallery, position),
+              handleSecondaryTapCard: handleSecondaryTapCard == null
+                  ? null
+                  : (gallery, position) =>
+                      handleSecondaryTapCard(gallery, position),
+              withTags: listMode == ListMode.listWithTags ||
+                  listMode == ListMode.flat,
             ),
           );
         },
@@ -68,28 +85,42 @@ Widget EHGalleryCollection({
       sliver: SliverWaterfallFlow(
         gridDelegate: styleSetting.crossAxisCountInWaterFallFlow.value == null
             ? SliverWaterfallFlowDelegateWithMaxCrossAxisExtent(
-                maxCrossAxisExtent: listMode == ListMode.waterfallFlowBig ? UIConfig.waterFallFlowCardWidthBig : UIConfig.waterFallFlowCardWidthSmall,
+                maxCrossAxisExtent: listMode == ListMode.waterfallFlowBig
+                    ? UIConfig.waterFallFlowCardWidthBig
+                    : UIConfig.waterFallFlowCardWidthSmall,
                 mainAxisSpacing: listMode == ListMode.waterfallFlowBig ? 10 : 5,
                 crossAxisSpacing: 5,
               )
             : SliverWaterfallFlowDelegateWithFixedCrossAxisCount(
-                crossAxisCount: styleSetting.crossAxisCountInWaterFallFlow.value!,
+                crossAxisCount:
+                    styleSetting.crossAxisCountInWaterFallFlow.value!,
                 mainAxisSpacing: listMode == ListMode.waterfallFlowBig ? 10 : 5,
                 crossAxisSpacing: 5,
               ),
         delegate: SliverChildBuilderDelegate(
           (BuildContext context, int index) {
-            if (index == gallerys.length - 1 && loadingState == LoadingState.idle && handleLoadMore != null) {
-              SchedulerBinding.instance.addPostFrameCallback((_) => handleLoadMore());
+            if (index == gallerys.length - 1 &&
+                loadingState == LoadingState.idle &&
+                handleLoadMore != null) {
+              SchedulerBinding.instance
+                  .addPostFrameCallback((_) => handleLoadMore());
             }
 
             return EHGalleryWaterFlowCard(
               gallery: gallerys[index],
-              downloaded: galleryDownloadService.containGallery(gallerys[index].gid) || archiveDownloadService.containArchive(gallerys[index].gid),
+              downloaded: galleryDownloadService
+                      .containGallery(gallerys[index].gid) ||
+                  archiveDownloadService.containArchive(gallerys[index].gid),
               listMode: listMode,
               handleTapCard: handleTapCard,
-              handleLongPressCard: handleLongPressCard == null ? null : (gallery, position) => handleLongPressCard(gallery, position),
-              handleSecondaryTapCard: handleSecondaryTapCard == null ? null : (gallery, position) => handleSecondaryTapCard(gallery, position),
+              handleLongPressCard: handleLongPressCard == null
+                  ? null
+                  : (gallery, position) =>
+                      handleLongPressCard(gallery, position),
+              handleSecondaryTapCard: handleSecondaryTapCard == null
+                  ? null
+                  : (gallery, position) =>
+                      handleSecondaryTapCard(gallery, position),
             );
           },
           childCount: gallerys.length,
@@ -98,7 +129,10 @@ Widget EHGalleryCollection({
     );
   }
 
-  if (listMode == ListMode.flat || listMode == ListMode.flatWithoutTags || listMode == ListMode.listWithoutTags || listMode == ListMode.listWithTags) {
+  if (listMode == ListMode.flat ||
+      listMode == ListMode.flatWithoutTags ||
+      listMode == ListMode.listWithoutTags ||
+      listMode == ListMode.listWithTags) {
     return _buildGalleryList();
   }
 

--- a/lib/src/widget/eh_gallery_list_card_.dart
+++ b/lib/src/widget/eh_gallery_list_card_.dart
@@ -5,6 +5,7 @@ import 'package:blur/blur.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_rating_bar/flutter_rating_bar.dart';
 import 'package:get/get.dart';
+import 'package:jhentai/src/config/theme_config.dart';
 import 'package:jhentai/src/config/ui_config.dart';
 import 'package:jhentai/src/extension/widget_extension.dart';
 import 'package:jhentai/src/model/gallery.dart';
@@ -21,7 +22,8 @@ import 'eh_gallery_category_tag.dart';
 import '../service/read_progress_service.dart';
 
 typedef CardCallback = FutureOr<void> Function(Gallery gallery);
-typedef CardContextMenuCallback = void Function(Gallery gallery, Offset position);
+typedef CardContextMenuCallback = void Function(
+    Gallery gallery, Offset position);
 
 class EHGalleryListCard extends StatelessWidget {
   final Gallery gallery;
@@ -48,19 +50,43 @@ class EHGalleryListCard extends StatelessWidget {
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTap: () => handleTapCard(gallery),
-      onLongPressStart: handleLongPressCard == null ? null : (details) => handleLongPressCard!(gallery, details.globalPosition),
-      onSecondaryTapDown: handleSecondaryTapCard == null ? null : (details) => handleSecondaryTapCard!(gallery, details.globalPosition),
+      onLongPressStart: handleLongPressCard == null
+          ? null
+          : (details) => handleLongPressCard!(gallery, details.globalPosition),
+      onSecondaryTapDown: handleSecondaryTapCard == null
+          ? null
+          : (details) =>
+              handleSecondaryTapCard!(gallery, details.globalPosition),
       child: FadeIn(
         duration: const Duration(milliseconds: 100),
         child: SizedBox(
-          height: withTags ? UIConfig.galleryCardHeight : UIConfig.galleryCardHeightWithoutTags,
-          child: listMode == ListMode.flat || listMode == ListMode.flatWithoutTags ? buildFlatGalleryCard(context) : buildRoundGalleryCard(context),
+          height: withTags
+              ? UIConfig.galleryCardHeight
+              : UIConfig.galleryCardHeightWithoutTags,
+          child:
+              listMode == ListMode.flat || listMode == ListMode.flatWithoutTags
+                  ? buildFlatGalleryCard(context)
+                  : buildRoundGalleryCard(context),
         ),
       ),
     );
   }
 
   Widget buildRoundGalleryCard(BuildContext context) {
+    if (ThemeConfig.isApple) {
+      return DecoratedBox(
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.34),
+          border: Border(
+              bottom: BorderSide(
+                  width: 0.5,
+                  color:
+                      Theme.of(context).dividerColor.withValues(alpha: 0.75))),
+        ),
+        child: buildFlatGalleryCard(context, transparentBackground: true),
+      );
+    }
+
     return Container(
       decoration: BoxDecoration(
         color: UIConfig.backGroundColor(context),
@@ -80,11 +106,13 @@ class EHGalleryListCard extends StatelessWidget {
     );
   }
 
-  Widget buildFlatGalleryCard(BuildContext context) {
+  Widget buildFlatGalleryCard(BuildContext context,
+      {bool transparentBackground = false}) {
     List<Widget> children = [
       buildGalleryCardCover(context),
       Expanded(
-        child: buildGalleryCardInfo(context).paddingOnly(left: 6, right: 10, top: 6, bottom: 5),
+        child: buildGalleryCardInfo(context)
+            .paddingOnly(left: 6, right: 10, top: 6, bottom: 5),
       ),
     ];
 
@@ -93,7 +121,9 @@ class EHGalleryListCard extends StatelessWidget {
     }
 
     Widget child = ColoredBox(
-      color: UIConfig.backGroundColor(context),
+      color: transparentBackground
+          ? Colors.transparent
+          : UIConfig.backGroundColor(context),
       child: Row(children: children),
     );
 
@@ -106,8 +136,11 @@ class EHGalleryListCard extends StatelessWidget {
         overlay: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(Icons.cancel_outlined, size: UIConfig.galleryCardFilteredIconSize, color: UIConfig.onBackGroundColor(context)),
-            Text('filtered'.tr, style: TextStyle(color: UIConfig.onBackGroundColor(context))),
+            Icon(Icons.cancel_outlined,
+                size: UIConfig.galleryCardFilteredIconSize,
+                color: UIConfig.onBackGroundColor(context)),
+            Text('filtered'.tr,
+                style: TextStyle(color: UIConfig.onBackGroundColor(context))),
           ],
         ),
       );
@@ -120,8 +153,12 @@ class EHGalleryListCard extends StatelessWidget {
     return EHImage(
       galleryImage: gallery.cover,
       containerColor: UIConfig.galleryCardBackGroundColor(context),
-      containerHeight: withTags ? UIConfig.galleryCardHeight : UIConfig.galleryCardHeightWithoutTags,
-      containerWidth: withTags ? UIConfig.galleryCardCoverWidth : UIConfig.galleryCardCoverWidthWithoutTags,
+      containerHeight: withTags
+          ? UIConfig.galleryCardHeight
+          : UIConfig.galleryCardHeightWithoutTags,
+      containerWidth: withTags
+          ? UIConfig.galleryCardCoverWidth
+          : UIConfig.galleryCardCoverWidthWithoutTags,
       heroTag: gallery.blockedByLocalRules ? null : gallery.cover,
       fit: BoxFit.fitWidth,
     );
@@ -133,7 +170,8 @@ class EHGalleryListCard extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         buildGalleryCardInfoHeader(context),
-        if (withTags && gallery.tags.isNotEmpty) buildGalleryCardTagWaterFlow(context),
+        if (withTags && gallery.tags.isNotEmpty)
+          buildGalleryCardTagWaterFlow(context),
         buildGalleryInfoFooter(context),
       ],
     );
@@ -148,12 +186,15 @@ class EHGalleryListCard extends StatelessWidget {
           gallery.title,
           maxLines: 2,
           overflow: TextOverflow.ellipsis,
-          style: const TextStyle(fontSize: UIConfig.galleryCardTitleSize, height: 1.2),
+          style: const TextStyle(
+              fontSize: UIConfig.galleryCardTitleSize, height: 1.2),
         ),
         if (gallery.uploader != null)
           Text(
             gallery.uploader!,
-            style: TextStyle(fontSize: UIConfig.galleryCardTextSize, color: UIConfig.galleryCardTextColor(context)),
+            style: TextStyle(
+                fontSize: UIConfig.galleryCardTextSize,
+                color: UIConfig.galleryCardTextColor(context)),
           ).marginOnly(top: 2),
       ],
     );
@@ -203,10 +244,12 @@ class EHGalleryListCard extends StatelessWidget {
           children: [
             EHGalleryCategoryTag(category: gallery.category),
             const Expanded(child: SizedBox()),
-            if (gallery.pageCount != null) _buildReadingProgress(context).marginOnly(right: 8),
+            if (gallery.pageCount != null)
+              _buildReadingProgress(context).marginOnly(right: 8),
             if (downloaded) _buildDownloadIcon(context).marginOnly(right: 4),
             if (gallery.isFavorite) _buildFavoriteIcon().marginOnly(right: 4),
-            if (gallery.language != null) _buildLanguage(context).marginOnly(right: 4),
+            if (gallery.language != null)
+              _buildLanguage(context).marginOnly(right: 4),
             if (gallery.pageCount != null) _buildPageCount(context),
           ],
         ),
@@ -232,7 +275,9 @@ class EHGalleryListCard extends StatelessWidget {
       ignoreGestures: true,
       itemBuilder: (context, _) => Icon(
         Icons.star,
-        color: gallery.hasRated ? UIConfig.galleryRatingStarRatedColor(context) : UIConfig.galleryRatingStarColor,
+        color: gallery.hasRated
+            ? UIConfig.galleryRatingStarRatedColor(context)
+            : UIConfig.galleryRatingStarColor,
       ),
       onRatingUpdate: (rating) {},
     );
@@ -252,7 +297,10 @@ class EHGalleryListCard extends StatelessWidget {
 
             final readIndex = snapshot.data ?? 0;
 
-            double progress = gallery.pageCount != null && gallery.pageCount! > 0 ? ((readIndex + 1) / gallery.pageCount!).clamp(0.0, 1.0) : 0.0;
+            double progress =
+                gallery.pageCount != null && gallery.pageCount! > 0
+                    ? ((readIndex + 1) / gallery.pageCount!).clamp(0.0, 1.0)
+                    : 0.0;
 
             // Don't show indicator if no progress
             if (readIndex == 0.0) {
@@ -265,8 +313,10 @@ class EHGalleryListCard extends StatelessWidget {
               child: CircularProgressIndicator(
                 value: progress,
                 strokeWidth: 2,
-                backgroundColor: UIConfig.galleryCardTextColor(context).withValues(alpha: 0.2),
-                valueColor: AlwaysStoppedAnimation<Color>(UIConfig.galleryCardTextColor(context)),
+                backgroundColor: UIConfig.galleryCardTextColor(context)
+                    .withValues(alpha: 0.2),
+                valueColor: AlwaysStoppedAnimation<Color>(
+                    UIConfig.galleryCardTextColor(context)),
               ),
             );
           },
@@ -275,23 +325,32 @@ class EHGalleryListCard extends StatelessWidget {
     );
   }
 
-  Widget _buildDownloadIcon(BuildContext context) => Icon(Icons.downloading, size: 11, color: UIConfig.galleryCardTextColor(context));
+  Widget _buildDownloadIcon(BuildContext context) => Icon(Icons.downloading,
+      size: 11, color: UIConfig.galleryCardTextColor(context));
 
-  Widget _buildFavoriteIcon() => Icon(Icons.favorite, size: 11, color: UIConfig.favoriteTagColor[gallery.favoriteTagIndex!]);
+  Widget _buildFavoriteIcon() => Icon(Icons.favorite,
+      size: 11, color: UIConfig.favoriteTagColor[gallery.favoriteTagIndex!]);
 
   Text _buildPageCount(BuildContext context) =>
-      Text(gallery.pageCount.toString() + 'P', style: TextStyle(fontSize: UIConfig.galleryCardTextSize, color: UIConfig.galleryCardTextColor(context)));
+      Text(gallery.pageCount.toString() + 'P',
+          style: TextStyle(
+              fontSize: UIConfig.galleryCardTextSize,
+              color: UIConfig.galleryCardTextColor(context)));
 
   Text _buildLanguage(BuildContext context) {
     return Text(
       LocaleConsts.language2Abbreviation[gallery.language] ?? '',
-      style: TextStyle(fontSize: UIConfig.galleryCardTextSize, color: UIConfig.galleryCardTextColor(context)),
+      style: TextStyle(
+          fontSize: UIConfig.galleryCardTextSize,
+          color: UIConfig.galleryCardTextColor(context)),
     );
   }
 
   Text _buildTime(BuildContext context) {
     return Text(
-      preferenceSetting.showUtcTime.isTrue ? gallery.publishTime : DateUtil.transformUtc2LocalTimeString(gallery.publishTime),
+      preferenceSetting.showUtcTime.isTrue
+          ? gallery.publishTime
+          : DateUtil.transformUtc2LocalTimeString(gallery.publishTime),
       style: TextStyle(
           fontSize: UIConfig.galleryCardTextSize,
           color: UIConfig.galleryCardTextColor(context),

--- a/lib/src/widget/eh_gallery_waterflow_card.dart
+++ b/lib/src/widget/eh_gallery_waterflow_card.dart
@@ -6,6 +6,7 @@ import 'package:blur/blur.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_rating_bar/flutter_rating_bar.dart';
 import 'package:get/get.dart';
+import 'package:jhentai/src/config/theme_config.dart';
 import 'package:jhentai/src/extension/string_extension.dart';
 import 'package:jhentai/src/extension/widget_extension.dart';
 import 'package:jhentai/src/setting/style_setting.dart';
@@ -41,20 +42,39 @@ class EHGalleryWaterFlowCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () => handleTapCard(gallery),
-      onLongPressStart: handleLongPressCard == null ? null : (details) => handleLongPressCard!(gallery, details.globalPosition),
-      onSecondaryTapDown: handleSecondaryTapCard == null ? null : (details) => handleSecondaryTapCard!(gallery, details.globalPosition),
+      onLongPressStart: handleLongPressCard == null
+          ? null
+          : (details) => handleLongPressCard!(gallery, details.globalPosition),
+      onSecondaryTapDown: handleSecondaryTapCard == null
+          ? null
+          : (details) =>
+              handleSecondaryTapCard!(gallery, details.globalPosition),
       child: FadeIn(child: _buildCard(context)),
     );
   }
 
   Widget _buildCard(BuildContext context) {
-    Widget child = Card(
-      child: listMode == ListMode.waterfallFlowSmall
-          ? _buildSmallCard(context)
-          : listMode == ListMode.waterfallFlowMedium
-              ? _buildMediumCard(context)
-              : _buildBigCard(context),
-    );
+    final Widget content = listMode == ListMode.waterfallFlowSmall
+        ? _buildSmallCard(context)
+        : listMode == ListMode.waterfallFlowMedium
+            ? _buildMediumCard(context)
+            : _buildBigCard(context);
+    Widget child = ThemeConfig.isApple
+        ? DecoratedBox(
+            decoration: BoxDecoration(
+              color: Theme.of(context)
+                  .colorScheme
+                  .surfaceContainerHighest
+                  .withValues(alpha: 0.48),
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(
+                  color: Theme.of(context).dividerColor.withValues(alpha: 0.55),
+                  width: 0.5),
+            ),
+            child: ClipRRect(
+                borderRadius: BorderRadius.circular(8), child: content),
+          )
+        : Card(child: content);
 
     if (gallery.blockedByLocalRules) {
       child = Blur(
@@ -65,8 +85,11 @@ class EHGalleryWaterFlowCard extends StatelessWidget {
         overlay: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(Icons.cancel_outlined, size: UIConfig.galleryCardFilteredIconSize, color: UIConfig.onBackGroundColor(context)),
-            Text('filtered'.tr, style: TextStyle(color: UIConfig.onBackGroundColor(context))),
+            Icon(Icons.cancel_outlined,
+                size: UIConfig.galleryCardFilteredIconSize,
+                color: UIConfig.onBackGroundColor(context)),
+            Text('filtered'.tr,
+                style: TextStyle(color: UIConfig.onBackGroundColor(context))),
           ],
         ),
       );
@@ -101,7 +124,8 @@ class EHGalleryWaterFlowCard extends StatelessWidget {
                 _buildRatingBar(context),
                 const Expanded(child: SizedBox()),
                 if (downloaded) _buildDownloadIcon().marginOnly(right: 2),
-                if (gallery.isFavorite) _buildFavoriteIcon().marginOnly(right: 2),
+                if (gallery.isFavorite)
+                  _buildFavoriteIcon().marginOnly(right: 2),
                 if (gallery.pageCount != null) _buildPageCount(),
               ],
             ),
@@ -125,9 +149,11 @@ class EHGalleryWaterFlowCard extends StatelessWidget {
                 _buildRatingBar(context),
                 const Expanded(child: SizedBox()),
                 if (downloaded) _buildDownloadIcon(),
-                if (gallery.isFavorite) _buildFavoriteIcon().marginOnly(left: 2),
+                if (gallery.isFavorite)
+                  _buildFavoriteIcon().marginOnly(left: 2),
                 _buildCategory().marginOnly(left: 4, right: 4),
-                if (gallery.language != null) _buildLanguage().marginOnly(right: 2),
+                if (gallery.language != null)
+                  _buildLanguage().marginOnly(right: 2),
                 if (gallery.pageCount != null) _buildPageCount(),
               ],
             ),
@@ -149,7 +175,9 @@ class EHGalleryWaterFlowCard extends StatelessWidget {
             constraints.maxWidth,
             min(
               constraints.maxHeight,
-              listMode == ListMode.waterfallFlowBig ? UIConfig.waterFallFlowCardMaxHeightBig : UIConfig.waterFallFlowCardMaxHeightSmall,
+              listMode == ListMode.waterfallFlowBig
+                  ? UIConfig.waterFallFlowCardMaxHeightBig
+                  : UIConfig.waterFallFlowCardMaxHeightSmall,
             ),
           ),
         );
@@ -161,10 +189,21 @@ class EHGalleryWaterFlowCard extends StatelessWidget {
           containerColor: UIConfig.waterFallFlowCardBackGroundColor(context),
           heroTag: gallery.blockedByLocalRules ? null : gallery.cover,
           borderRadius: BorderRadius.only(
-            topLeft: Radius.circular(listMode == ListMode.waterfallFlowBig ? 12 : 8),
-            topRight: Radius.circular(listMode == ListMode.waterfallFlowBig ? 12 : 8),
-            bottomLeft: Radius.circular(listMode == ListMode.waterfallFlowBig || listMode == ListMode.waterfallFlowMedium ? 0 : 8),
-            bottomRight: Radius.circular(listMode == ListMode.waterfallFlowBig || listMode == ListMode.waterfallFlowMedium ? 0 : 8),
+            topLeft: Radius.circular(ThemeConfig.isApple
+                ? 8
+                : (listMode == ListMode.waterfallFlowBig ? 12 : 8)),
+            topRight: Radius.circular(ThemeConfig.isApple
+                ? 8
+                : (listMode == ListMode.waterfallFlowBig ? 12 : 8)),
+            bottomLeft: Radius.circular(listMode == ListMode.waterfallFlowBig ||
+                    listMode == ListMode.waterfallFlowMedium
+                ? 0
+                : 8),
+            bottomRight: Radius.circular(
+                listMode == ListMode.waterfallFlowBig ||
+                        listMode == ListMode.waterfallFlowMedium
+                    ? 0
+                    : 8),
           ),
         );
       },
@@ -173,13 +212,18 @@ class EHGalleryWaterFlowCard extends StatelessWidget {
 
   Widget _buildLanguageChip() {
     return Container(
-      decoration: BoxDecoration(color: UIConfig.galleryCategoryColor[gallery.category]!, borderRadius: BorderRadius.circular(12)),
+      decoration: BoxDecoration(
+          color: UIConfig.galleryCategoryColor[gallery.category]!,
+          borderRadius: BorderRadius.circular(12)),
       padding: const EdgeInsets.symmetric(horizontal: 4),
       constraints: const BoxConstraints(minWidth: 12),
       child: Center(
         child: Text(
           LocaleConsts.language2Abbreviation[gallery.language] ?? '',
-          style: TextStyle(fontSize: 9, color: UIConfig.waterFallFlowCardLanguageChipTextColor(UIConfig.galleryCategoryColor[gallery.category]!)),
+          style: TextStyle(
+              fontSize: 9,
+              color: UIConfig.waterFallFlowCardLanguageChipTextColor(
+                  UIConfig.galleryCategoryColor[gallery.category]!)),
         ),
       ),
     );
@@ -187,11 +231,15 @@ class EHGalleryWaterFlowCard extends StatelessWidget {
 
   Widget _buildDownloadIcon() => const Icon(Icons.download, size: 10);
 
-  Widget _buildFavoriteIcon() => Icon(Icons.favorite, size: 10, color: UIConfig.favoriteTagColor[gallery.favoriteTagIndex!]);
+  Widget _buildFavoriteIcon() => Icon(Icons.favorite,
+      size: 10, color: UIConfig.favoriteTagColor[gallery.favoriteTagIndex!]);
 
-  Widget _buildPageCount() => Text(gallery.pageCount.toString() + 'P', style: const TextStyle(fontSize: 9));
+  Widget _buildPageCount() => Text(gallery.pageCount.toString() + 'P',
+      style: const TextStyle(fontSize: 9));
 
-  Widget _buildLanguage() => Text(LocaleConsts.language2Abbreviation[gallery.language] ?? '', style: const TextStyle(fontSize: 9));
+  Widget _buildLanguage() =>
+      Text(LocaleConsts.language2Abbreviation[gallery.language] ?? '',
+          style: const TextStyle(fontSize: 9));
 
   Widget _buildRatingBar(BuildContext context) {
     return RatingBar.builder(
@@ -201,7 +249,10 @@ class EHGalleryWaterFlowCard extends StatelessWidget {
       allowHalfRating: true,
       itemSize: 11,
       ignoreGestures: true,
-      itemBuilder: (context, _) => Icon(Icons.star, color: gallery.hasRated ? UIConfig.galleryRatingStarRatedColor(context) : UIConfig.galleryRatingStarColor),
+      itemBuilder: (context, _) => Icon(Icons.star,
+          color: gallery.hasRated
+              ? UIConfig.galleryRatingStarRatedColor(context)
+              : UIConfig.galleryRatingStarColor),
       onRatingUpdate: (_) {},
     );
   }
@@ -209,7 +260,8 @@ class EHGalleryWaterFlowCard extends StatelessWidget {
   Widget _buildCategory() {
     return EHGalleryCategoryTag(
       category: gallery.category,
-      textStyle: const TextStyle(fontSize: 8, color: UIConfig.galleryCategoryTagTextColor),
+      textStyle: const TextStyle(
+          fontSize: 8, color: UIConfig.galleryCategoryTagTextColor),
       padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
     );
   }
@@ -219,7 +271,8 @@ class EHGalleryWaterFlowCard extends StatelessWidget {
       gallery.title.breakWord,
       maxLines: 3,
       overflow: TextOverflow.ellipsis,
-      style: const TextStyle(fontSize: UIConfig.waterFallFlowCardTitleSize, height: 1.2),
+      style: const TextStyle(
+          fontSize: UIConfig.waterFallFlowCardTitleSize, height: 1.2),
     );
   }
 
@@ -231,7 +284,8 @@ class EHGalleryWaterFlowCard extends StatelessWidget {
 class WaterFallFlowCardTagWaterFlow extends StatelessWidget {
   final LinkedHashMap<String, List<GalleryTag>> tags;
 
-  const WaterFallFlowCardTagWaterFlow({Key? key, required this.tags}) : super(key: key);
+  const WaterFallFlowCardTagWaterFlow({Key? key, required this.tags})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -256,7 +310,8 @@ class WaterFallFlowCardTagWaterFlow extends StatelessWidget {
             crossAxisSpacing: 4,
           ),
           itemCount: mergedList.length,
-          itemBuilder: (_, int index) => WaterFallFlowTag(galleryTag: mergedList[index]),
+          itemBuilder: (_, int index) =>
+              WaterFallFlowTag(galleryTag: mergedList[index]),
         ).enableMouseDrag(withScrollBar: false),
       );
     });
@@ -268,7 +323,8 @@ class WaterFallFlowCardTagWaterFlow extends StatelessWidget {
 }
 
 class WaterFallFlowTag extends StatelessWidget {
-  const WaterFallFlowTag({Key? key, required this.galleryTag}) : super(key: key);
+  const WaterFallFlowTag({Key? key, required this.galleryTag})
+      : super(key: key);
 
   final GalleryTag galleryTag;
 
@@ -277,7 +333,8 @@ class WaterFallFlowTag extends StatelessWidget {
     return Container(
       alignment: Alignment.center,
       decoration: BoxDecoration(
-        color: galleryTag.backgroundColor ?? UIConfig.ehTagBackGroundColor(context),
+        color: galleryTag.backgroundColor ??
+            UIConfig.ehTagBackGroundColor(context),
         borderRadius: BorderRadius.circular(6),
       ),
       padding: const EdgeInsets.symmetric(horizontal: 4),

--- a/lib/src/widget/grouped_list.dart
+++ b/lib/src/widget/grouped_list.dart
@@ -27,6 +27,9 @@ class GroupedList<G, E> extends StatefulWidget {
 
   final GroupedListController? controller;
 
+  /// Extra trailing scroll extent (e.g. to clear a floating bottom bar).
+  final double bottomPadding;
+
   const GroupedList({
     Key? key,
     required this.groups,
@@ -39,6 +42,7 @@ class GroupedList<G, E> extends StatefulWidget {
     required this.maxGalleryNum4Animation,
     this.scrollController,
     this.controller,
+    this.bottomPadding = 0,
   }) : super(key: key);
 
   @override
@@ -149,7 +153,11 @@ class _GroupedListState<G, E> extends State<GroupedList<G, E>> {
       child: CustomScrollView(
         controller: scrollController,
         scrollCacheExtent: ScrollCacheExtent.pixels(200),
-        slivers: _buildSlivers(context),
+        slivers: [
+          ..._buildSlivers(context),
+          if (widget.bottomPadding > 0)
+            SliverPadding(padding: EdgeInsets.only(bottom: widget.bottomPadding)),
+        ],
       ),
     );
   }

--- a/lib/src/widget/icon_text_button.dart
+++ b/lib/src/widget/icon_text_button.dart
@@ -32,6 +32,7 @@ class IconTextButton extends StatelessWidget {
           splashColor: Colors.transparent,
           highlightColor: Colors.transparent,
           hoverColor: Colors.transparent,
+          mouseCursor: SystemMouseCursors.basic,
           onPressed: onPressed,
           icon: Column(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -11,6 +11,7 @@ import desktop_webview_window
 import device_info_plus
 import just_audio
 import local_auth_darwin
+import macos_window_utils
 import package_info_plus
 import pasteboard
 import path_provider_foundation
@@ -33,6 +34,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
   FLALocalAuthPlugin.register(with: registry.registrar(forPlugin: "FLALocalAuthPlugin"))
+  MacOSWindowUtilsPlugin.register(with: registry.registrar(forPlugin: "MacOSWindowUtilsPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PasteboardPlugin.register(with: registry.registrar(forPlugin: "PasteboardPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.15'
+platform :osx, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -36,5 +36,8 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_macos_build_settings(target)
+    target.build_configurations.each do |config|
+      config.build_settings['MACOSX_DEPLOYMENT_TARGET'] = '12.0'
+    end
   end
 end

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -54,17 +54,17 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/window_manager/macos
 
 SPEC CHECKSUMS:
-  audio_session: dea1f41890dbf1718f04a56f1d6150fd50039b72
-  desktop_webview_window: d4365e71bcd4e1aa0c14cf0377aa24db0c16a7e2
+  audio_session: 48ab6500f7a5e7c64363e206565a5dfe5a0c1441
+  desktop_webview_window: 7e37af677d6d19294cb433d9b1d878ef78dffa4d
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  just_audio: 9b67ca7b97c61cfc9784ea23cd8cc55eb226d489
-  package_info_plus: d2f71247aab4b6521434f887276093acc70d214c
-  screen_brightness_macos: 2d6d3af2165592d9a55ffcd95b7550970e41ebda
-  screen_retriever: 59634572a57080243dd1bf715e55b6c54f241a38
-  smart_auth: b38e3ab4bfe089eacb1e233aca1a2340f96c28e9
-  wakelock_plus: 4783562c9a43d209c458cb9b30692134af456269
-  window_manager: 3a1844359a6295ab1e47659b1a777e36773cd6e8
+  just_audio: eb8b016ac4493159ab24db4f7215e55303b39a84
+  package_info_plus: 4f85435d47d3cdedb9b420d168afd080840708ea
+  screen_brightness_macos: 2a3ee243f8051c340381e8e51bcedced8360f421
+  screen_retriever: 4f97c103641aab8ce183fa5af3b87029df167936
+  smart_auth: e10f1d22af5d9e1a51964fb1826cb177f993a7e1
+  wakelock_plus: 21ddc249ac4b8d018838dbdabd65c5976c308497
+  window_manager: 1d01fa7ac65a6e6f83b965471b1a7fdd3f06166c
 
-PODFILE CHECKSUM: 0d3963a09fc94f580682bd88480486da345dc3f0
+PODFILE CHECKSUM: 7ea94091761b499e0c705bed8ccc305efda9867b
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.17.0

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -415,7 +415,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -438,7 +438,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
@@ -496,7 +496,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -543,7 +543,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -566,7 +566,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -577,6 +577,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 33E5194F232828860026EE4D /* AppInfo.xcconfig */;
 			buildSettings = {
+				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
@@ -588,7 +589,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
@@ -605,6 +606,7 @@
 		33CC111D2044C6BA0003C045 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = arm64;
 				CODE_SIGN_STYLE = Automatic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -1,21 +1,25 @@
 import Cocoa
 import FlutterMacOS
+import macos_window_utils
 import window_manager
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
-    let flutterViewController = FlutterViewController.init()
     let windowFrame = self.frame
-    self.contentViewController = flutterViewController
+    let macOSWindowUtilsViewController = MacOSWindowUtilsViewController()
+    self.contentViewController = macOSWindowUtilsViewController
     self.setFrame(windowFrame, display: true)
 
-    RegisterGeneratedPlugins(registry: flutterViewController)
+    /* Initialize the macos_window_utils plugin */
+    MainFlutterWindowManipulator.start(mainFlutterWindow: self)
+
+    RegisterGeneratedPlugins(registry: macOSWindowUtilsViewController.flutterViewController)
 
     super.awakeFromNib()
   }
-  
+
   override public func order(_ place: NSWindow.OrderingMode, relativeTo otherWin: Int) {
-      super.order(place, relativeTo: otherWin)
-      hiddenWindowAtLaunch()
-   }
+    super.order(place, relativeTo: otherWin)
+    hiddenWindowAtLaunch()
+  }
 }

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -5,6 +5,9 @@ import window_manager
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
+    titleVisibility = .visible
+    titlebarAppearsTransparent = false
+
     let windowFrame = self.frame
     let macOSWindowUtilsViewController = MacOSWindowUtilsViewController()
     self.contentViewController = macOSWindowUtilsViewController

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -958,6 +958,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  liquid_glass_easy:
+    dependency: "direct main"
+    description:
+      name: liquid_glass_easy
+      sha256: "7b5980233a8502bc655225c666ae7bebed1b2e0217460167f8a4ab32f78fb69f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.5.0"
   loading_animation_widget:
     dependency: "direct main"
     description:
@@ -1022,6 +1030,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  macos_window_utils:
+    dependency: "direct main"
+    description:
+      name: macos_window_utils
+      sha256: cb918e1ff0b31fdaa5cd8631eded7c24bd72e1025cf1f95c819e483f0057c652
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.9.1"
   matcher:
     dependency: "direct overridden"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -131,6 +131,10 @@ dependencies:
   volume_button_override:
     git:
       url: https://github.com/jiangtian616/volume_button_override
+  # Apple Liquid Glass UI (macOS/iOS style)
+  liquid_glass_easy: ^3.5.0
+  # macOS native window vibrancy (translucent sidebar / title bar)
+  macos_window_utils: ^1.9.1
 
 dependency_overrides:
   test_api: 0.6.0


### PR DESCRIPTION
## Summary

- Adds an opt-in Apple visual style in Style settings, available only on iOS and macOS.
- Keeps the existing Material interface unchanged by default and on Android, Windows, Linux, and Web.
- Adds the macOS sidebar, title-bar, settings, gallery, detail, search, and animation refinements, plus the iOS Liquid Glass bottom navigation treatment.
- Preserves user-selectable accent colors and applies the current iOS liquid-glass tuning: dark-mode text contrast, restrained opacity, and a non-glowing dark outline.

## Behavior

The setting is off by default. Enabling it rebuilds the visual hierarchy immediately; on macOS it also switches the native title bar into the full-size transparent presentation. Disabling it restores the normal title bar and original Material layout.

## Validation

- `flutter analyze` completed with no new errors.
- Rebuilt the unsigned iOS device IPA while validating the Liquid Glass changes.

## Review focus

- Confirm the opt-in default and the visual-mode copy.
- Check the iOS Liquid Glass opacity and dark-mode border against device screenshots.
- Check macOS title-bar restoration when the setting is toggled off.