### PR TITLE
Add local title blocking to the title selection menu

### DIFF
--- a/lib/src/l18n/en_US.dart
+++ b/lib/src/l18n/en_US.dart
@@ -200,6 +200,8 @@ class en_US {
       'addTagFailed': 'Add Tag Failed',
       'parentGallery': 'Parent',
       'blockUploaderLocally': 'Block user locally',
+      'blockTitleLocally': 'Block selected title locally',
+      'blockRuleAlreadyExists': 'This rule already exists',
       'block': 'Block',
 
       /// detail dialog

--- a/lib/src/l18n/ko_KR.dart
+++ b/lib/src/l18n/ko_KR.dart
@@ -200,6 +200,8 @@ class ko_KR {
       'addTagFailed': 'Add Tag Failed',
       'parentGallery': 'Parent',
       'blockUploaderLocally': 'Block user locally',
+      'blockTitleLocally': '선택한 제목을 로컬에서 차단',
+      'blockRuleAlreadyExists': '이 규칙은 이미 존재합니다',
       'block': 'Block',
 
       /// detail dialog

--- a/lib/src/l18n/pt_BR.dart
+++ b/lib/src/l18n/pt_BR.dart
@@ -201,6 +201,8 @@ class pt_BR {
       'addTagFailed': 'Add Tag Failed',
       'parentGallery': 'Parent',
       'blockUploaderLocally': 'Block user locally',
+      'blockTitleLocally': 'Bloquear título selecionado localmente',
+      'blockRuleAlreadyExists': 'Esta regra já existe',
       'block': 'Block',
 
       /// detail dialog

--- a/lib/src/l18n/ru_RU.dart
+++ b/lib/src/l18n/ru_RU.dart
@@ -203,6 +203,8 @@ class ru_RU {
       'addTagFailed': 'Не удалось добавить тег',
       'parentGallery': 'Родительская галерея',
       'blockUploaderLocally': 'Заблокировать пользователя локально',
+      'blockTitleLocally': 'Заблокировать выбранное название локально',
+      'blockRuleAlreadyExists': 'Это правило уже существует',
       'block': 'Block',
 
       /// detail dialog

--- a/lib/src/l18n/zh_CN.dart
+++ b/lib/src/l18n/zh_CN.dart
@@ -200,6 +200,8 @@ class zh_CN {
       'addTagFailed': '添加标签失败',
       'parentGallery': '父画廊',
       'blockUploaderLocally': '本地屏蔽上传者',
+      'blockTitleLocally': '本地屏蔽已选中标题',
+      'blockRuleAlreadyExists': '该规则已存在',
       'block': '屏蔽',
 
       /// detail dialog

--- a/lib/src/l18n/zh_TW.dart
+++ b/lib/src/l18n/zh_TW.dart
@@ -200,6 +200,8 @@ class zh_TW {
       'addTagFailed': '新增標籤失敗',
       'parentGallery': '父畫廊',
       'blockUploaderLocally': '於本機端隱藏的上傳者',
+      'blockTitleLocally': '於本機端隱藏已選取的標題',
+      'blockRuleAlreadyExists': '該規則已存在',
       'block': '隱藏',
 
       /// detail dialog

--- a/lib/src/pages/details/details_page.dart
+++ b/lib/src/pages/details/details_page.dart
@@ -45,6 +45,7 @@ import 'details_page_state.dart';
 
 class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
   final String tag = newUUID();
+  final bool enableLocalTitleBlocking;
 
   late final DetailsPageLogic logic;
   late final DetailsPageState state;
@@ -55,12 +56,12 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
   @override
   Scroll2TopStateMixin get scroll2TopState => state;
 
-  DetailsPage({super.key}) {
+  DetailsPage({super.key}) : enableLocalTitleBlocking = true {
     logic = Get.put(DetailsPageLogic(), tag: tag);
     state = logic.state;
   }
 
-  DetailsPage.preview({super.key});
+  DetailsPage.preview({super.key}) : enableLocalTitleBlocking = false;
 
   @override
   Widget build(BuildContext context) {
@@ -320,20 +321,7 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
               anchors: editableTextState.contextMenuAnchors,
             );
 
-            if (!editableTextState.currentTextEditingValue.selection.isCollapsed) {
-              toolbar.buttonItems?.add(
-                ContextMenuButtonItem(
-                  label: 'search'.tr,
-                  onPressed: () {
-                    ContextMenuController.removeAny();
-                    newSearch(
-                      keyword: editableTextState.currentTextEditingValue.selection.textInside(editableTextState.currentTextEditingValue.text),
-                      forceNewRoute: true,
-                    );
-                  },
-                ),
-              );
-            }
+            _appendTitleContextMenuItems(toolbar, editableTextState);
 
             return toolbar;
           },
@@ -385,20 +373,7 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
                     anchors: editableTextState.contextMenuAnchors,
                   );
 
-                  if (!editableTextState.currentTextEditingValue.selection.isCollapsed) {
-                    toolbar.buttonItems?.add(
-                      ContextMenuButtonItem(
-                        label: 'search'.tr,
-                        onPressed: () {
-                          ContextMenuController.removeAny();
-                          newSearch(
-                            keyword: editableTextState.currentTextEditingValue.selection.textInside(editableTextState.currentTextEditingValue.text),
-                            forceNewRoute: true,
-                          );
-                        },
-                      ),
-                    );
-                  }
+                  _appendTitleContextMenuItems(toolbar, editableTextState);
 
                   return toolbar;
                 },
@@ -406,6 +381,42 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
             );
           },
         ),
+      ),
+    );
+  }
+
+  void _appendTitleContextMenuItems(
+    AdaptiveTextSelectionToolbar toolbar,
+    EditableTextState editableTextState,
+  ) {
+    TextEditingValue editingValue = editableTextState.currentTextEditingValue;
+    if (editingValue.selection.isCollapsed) {
+      return;
+    }
+
+    String rawSelectedText = editingValue.selection.textInside(editingValue.text);
+    toolbar.buttonItems?.add(
+      ContextMenuButtonItem(
+        label: 'search'.tr,
+        onPressed: () {
+          ContextMenuController.removeAny();
+          newSearch(keyword: rawSelectedText, forceNewRoute: true);
+        },
+      ),
+    );
+
+    String selectedText = rawSelectedText.trim();
+    if (!enableLocalTitleBlocking || selectedText.isEmpty) {
+      return;
+    }
+
+    toolbar.buttonItems?.add(
+      ContextMenuButtonItem(
+        label: 'blockTitleLocally'.tr,
+        onPressed: () {
+          ContextMenuController.removeAny();
+          logic.blockTitle(selectedText);
+        },
       ),
     );
   }

--- a/lib/src/pages/details/details_page_logic.dart
+++ b/lib/src/pages/details/details_page_logic.dart
@@ -989,6 +989,35 @@ class DetailsPageLogic extends GetxController with LoginRequiredMixin, Scroll2To
     toast('success'.tr);
   }
 
+  Future<void> blockTitle(String title) async {
+    String expression = title.trim();
+    if (expression.isEmpty) {
+      return;
+    }
+
+    LocalBlockRule rule = LocalBlockRule(
+      groupId: newUUID(),
+      target: LocalBlockTargetEnum.gallery,
+      attribute: LocalBlockAttributeEnum.title,
+      pattern: LocalBlockPatternEnum.like,
+      expression: expression,
+    );
+
+    try {
+      ({bool success, bool inserted, String? msg}) result = await localBlockRuleService.insertBlockRuleIfAbsent(rule);
+      if (!result.success) {
+        snack('configureBlockRuleFailed'.tr, result.msg ?? '');
+      } else if (result.inserted) {
+        toast('success'.tr);
+      } else {
+        toast('blockRuleAlreadyExists'.tr);
+      }
+    } catch (e, stack) {
+      log.error('Block title failed, expression:$expression', e, stack);
+      snack('configureBlockRuleFailed'.tr, e.toString());
+    }
+  }
+
   Future<void> handleResetReadProgress() async {
     await readProgressService.deleteReadProgress(state.galleryUrl.gid.toString());
     updateSafely([readButtonId]);

--- a/lib/src/service/local_block_rule_service.dart
+++ b/lib/src/service/local_block_rule_service.dart
@@ -151,6 +151,44 @@ class LocalBlockRuleService with JHLifeCircleBeanErrorCatch implements JHLifeCir
     return BlockRuleDao.existsGroup(groupId);
   }
 
+  Future<({bool success, bool inserted, String? msg})> insertBlockRuleIfAbsent(LocalBlockRule rule) async {
+    log.info('Insert block rule if absent: $rule');
+
+    LocalBlockRuleHandler handler = getHandlerByRule(rule);
+    ({bool success, String? msg}) validateResult = handler.validateRule(rule);
+    if (!validateResult.success) {
+      log.info('Insert block rule failed, result:$validateResult');
+      return (success: false, inserted: false, msg: validateResult.msg);
+    }
+
+    bool inserted = false;
+    await appDb.transaction(() async {
+      List<BlockRuleData> datas = await BlockRuleDao.selectBlockRulesByTarget(rule.target.code);
+      bool exists = datas.any(
+        (data) =>
+            data.attribute == rule.attribute.code &&
+            data.pattern == rule.pattern.code &&
+            data.expression == rule.expression,
+      );
+      if (exists) {
+        return;
+      }
+
+      await BlockRuleDao.insertBlockRule(
+        BlockRuleCompanion.insert(
+          groupId: rule.groupId!,
+          target: rule.target.code,
+          attribute: rule.attribute.code,
+          pattern: rule.pattern.code,
+          expression: rule.expression,
+        ),
+      );
+      inserted = true;
+    });
+
+    return (success: true, inserted: inserted, msg: null);
+  }
+
   Future<List<T>> executeRules<T>(List<T> items) async {
     List<T> results = List.of(items);
 


### PR DESCRIPTION
## Summary

- add a local title blocking action to the selection menus of both gallery titles
- create a `gallery / title / contains` local blocking rule from the trimmed selected text
- avoid inserting exact duplicate rules and show a localized message when one already exists
- add translations for all currently supported locales

## Motivation

The gallery details page already allows users to select and search title text. This adds a shortcut for creating the equivalent local “title contains” blocking rule without navigating to Preferences.

Related to #746.

## Validation

- `flutter analyze` (no new errors; the repository still reports existing warnings and infos)
- `git diff --check`
- clean Windows release build
- Windows startup smoke test
- manually tested on Windows and Android ARM64
- verified successful title blocking and duplicate-rule feedback on both platforms
