### PR TITLE
优化已下载画廊详情页，减少大量动图造成的卡顿

### DIFF
--- a/lib/src/pages/details/details_page.dart
+++ b/lib/src/pages/details/details_page.dart
@@ -211,7 +211,7 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
           physics: const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
           scrollBehavior: UIConfig.scrollBehaviourWithScrollBarWithMouse,
           controller: state.scrollController,
-          scrollCacheExtent: ScrollCacheExtent.pixels(5000),
+          scrollCacheExtent: const ScrollCacheExtent.pixels(250),
           slivers: [
             CupertinoSliverRefreshControl(onRefresh: logic.handleRefresh),
             if (preferenceSetting.showAllGalleryTitles.isTrue) _buildSubTitle(context),
@@ -1410,6 +1410,7 @@ class DetailsPage extends StatelessWidget with Scroll2TopPageMixin {
                                           containerWidth: constraints.maxWidth,
                                           borderRadius: BorderRadius.circular(8),
                                           maxBytes: 128 * 1024,
+                                          disableAnimation: true,
                                         )
                                       : EHThumbnail(
                                           thumbnail: state.galleryDetails!.thumbnails[index],


### PR DESCRIPTION
这次改动起因于我在一台老 iPad 上浏览已下载画廊时，遇到了明显卡顿和闪退，影响正常使用。为了找出原因并验证改动效果，我又在 Mac 上复现了详情页卡顿的问题，并进行了性能记录和对照测试。

在下载列表中点击已下载画廊的缩略图、右侧切换到详情页时，优化前的 Instruments 记录捕捉到一次约 **0.30 秒的界面无响应**。

详情页原先会提前加载屏幕外较大范围的内容。对于已下载图片，缩略图使用本地完整图片；当画廊包含大量体积较大的动图时，进入详情页就可能同时加载很多完整动图，并持续播放缩略图动画。

```mermaid
flowchart LR
A[打开已下载画廊详情页] --> B[提前加载大量屏幕外图片]
B --> C[小缩略图使用本地完整动图]
C --> D[集中加载与持续播放增加负担]
D --> E[切换页面时卡顿]
```

本 PR 只调整详情页的两处行为（1 个文件，新增 2 行、删除 1 行）：

- 将详情页提前加载范围从 5000 缩小到 250，让更多图片在滚动接近时再加载。此范围调整对详情页整体生效。
- 已下载图片的详情页缩略图只显示第一帧，进入阅读页后仍正常播放动图。

为了确认两项调整各自的作用，我在 Mac 上使用同一批本地 WebP 动图做了四组对照，每组观察 12 秒。测试基于 8.0.16（333），使用 Flutter 3.44.8 的 Profile 构建和复用实际图片组件的独立测试页面。

| 方案 | 加载图片数 | 图片更新次数 | 超过 50 毫秒的计时间隔次数 |
|---|---:|---:|---:|
| 原来的行为 | 92 | 1,991 | 4 |
| 只让缩略图静止 | 92 | 92 | 4 |
| 只减少提前加载 | 4 | 1,246 | 0 |
| 两项一起调整 | 4 | 4 | 0 |

这里的计时间隔用于观察运行期间的停顿，不等同于点击后的响应时间。四组按表中顺序在同一进程内执行，组间清理图片缓存；这是一组场景对照，并非多轮统计结果。

在这组测试布局下，加载图片对应的原文件总大小从约 **1.42 GB 降到 70.75 MB**，减少约 **95%**。这是涉及的文件大小合计，并非磁盘实际读取量。

对照结果说明，减少提前加载对缓解集中加载的负担更直接；让缩略图静止则进一步减少后续持续更新，因此最终保留了这两项调整。

随后在完整应用中验证了打开详情页、向下滚动、显示缩略图和进入阅读页。本次 Mac 复测没有记录到超过 250 毫秒的界面无响应，阅读页的动图仍能正常播放。修改文件的静态检查没有错误，仍有原有的 2 项警告和 1 项提示。

优化后，我也已经在原先出现问题的老 iPad 上进行了实际使用测试：**本次测试中没有再出现闪退，浏览和操作也已经非常流畅。**

iPad 上的结果来自实际操作体验，没有录制 Instruments 性能数据，因此不提供具体耗时或提升比例。上面的量化对照数据来自 Mac，不代表所有设备和画廊都能获得相同比例的改善。

相关讨论：[已下载画廊加载与缩略图优化 #614](https://github.com/jiangtian616/JHenTai/issues/614)。另有 [#802](https://github.com/jiangtian616/JHenTai/pull/802) 涉及阅读页动图优化；本次集中处理详情页的加载与缩略图播放负担，不将这些讨论中的其他问题一并视为已解决。
