### PR TITLE
修复旧版下载任务恢复时的长标题路径兼容问题

### DIFF
--- a/lib/src/service/gallery_download/download_path_resolver.dart
+++ b/lib/src/service/gallery_download/download_path_resolver.dart
@@ -15,6 +15,7 @@ import '../path_service.dart';
 /// the wrappers on [GalleryDownloadService] which do that automatically.
 class DownloadPathResolver {
   static const int maxFileNameBytes = 200;
+  static const int legacyGalleryTitleMaxChars = 85;
 
   /// Compute the sanitized title for the first time. Strips illegal file-name
   /// characters then truncates to fit within [maxFileNameBytes] bytes minus
@@ -22,6 +23,43 @@ class DownloadPathResolver {
   static String computeSanitizedGalleryTitle(String rawTitle, int reservedBytes) {
     String title = rawTitle.replaceAll(RegExp(r'[/|?,:*"<>\\.]'), ' ').trim();
     return FileUtil.truncateTitleToBytes(title, maxFileNameBytes - reservedBytes);
+  }
+
+  /// Reproduce the pre-sanitizedTitle gallery directory naming rule.
+  ///
+  /// Old releases sanitized illegal characters and then truncated the title to
+  /// 85 Dart string characters. Metadata written by those releases has no
+  /// `sanitizedTitle`, so using the current byte-based rule while restoring it
+  /// can point every image at a directory that never existed on disk.
+  static String computeLegacySanitizedGalleryTitle(String rawTitle) {
+    String title = rawTitle.replaceAll(RegExp(r'[/|?,:*"<>\\.]'), ' ').trim();
+    if (title.length > legacyGalleryTitleMaxChars) {
+      title = title.substring(0, legacyGalleryTitleMaxChars).trim();
+    }
+    return title;
+  }
+
+  /// Resolve the directory title to use while restoring metadata from disk.
+  ///
+  /// The directory currently being scanned is the strongest source of truth:
+  /// it is where the image bytes actually live. Prefer its `{gid} - {title}`
+  /// suffix even when metadata already contains a different `sanitizedTitle`.
+  /// This also repairs records that were restored once with the wrong newer
+  /// truncation rule. If the directory was renamed to a non-standard shape,
+  /// fall back to the persisted value, or finally the legacy 85-char rule for
+  /// metadata written before `sanitizedTitle` existed.
+  static String resolveSanitizedGalleryTitleForRestore({
+    required int gid,
+    required String rawTitle,
+    required String? persistedSanitizedTitle,
+    required String galleryDirectoryPath,
+  }) {
+    final String directoryName = path.basename(path.normalize(galleryDirectoryPath));
+    final String prefix = '$gid - ';
+    if (directoryName.startsWith(prefix)) {
+      return directoryName.substring(prefix.length);
+    }
+    return persistedSanitizedTitle ?? computeLegacySanitizedGalleryTitle(rawTitle);
   }
 
   /// Directory name format: '{gid} - {title}'

--- a/lib/src/service/gallery_download/gallery_download_service.dart
+++ b/lib/src/service/gallery_download/gallery_download_service.dart
@@ -825,9 +825,31 @@ class GalleryDownloadService extends GetxController with GridBasePageServiceMixi
         gallery = gallery.copyWith(downloadStatusIndex: DownloadStatus.paused.index);
       }
 
-      /// skip if exists
-      if (galleryDownloadInfos.containsKey(gallery.gid)) {
-        continue;
+      /// Existing tasks are normally skipped. Versions affected by #823 may
+      /// already have been restored with a sanitizedTitle that points to a
+      /// directory which never existed. If disk metadata now resolves to a
+      /// real directory instead, replace that stale record and restore it again.
+      final GalleryDownloadInfo? existingGallery = galleryDownloadInfos[gallery.gid];
+      if (existingGallery != null) {
+        if (!_shouldRepairRestoredGalleryPath(existingGallery, gallery, images)) {
+          continue;
+        }
+
+        log.info('Repair stale restored gallery path, gid: ${gallery.gid}');
+
+        /// Keep user-managed values that may have changed after the bad restore.
+        /// Only the restored path-related data should be replaced by the disk snapshot.
+        gallery = gallery.copyWith(
+          insertTime: existingGallery.insertTime,
+          priority: existingGallery.priority,
+          sortOrder: existingGallery.sortOrder,
+          groupName: existingGallery.group,
+          tags: existingGallery.tags,
+          tagRefreshTime: Value(existingGallery.tagRefreshTime),
+        );
+
+        await _clearGalleryDownloadInfoInDatabase(gallery.gid);
+        _clearGalleryInfoInMemory(existingGallery);
       }
 
       if (!await _restoreInfoInDatabase(gallery, images)) {
@@ -848,6 +870,15 @@ class GalleryDownloadService extends GetxController with GridBasePageServiceMixi
 
       _initGalleryInfoInMemoryWithImages(gallery, restoredImages);
 
+      /// Persist the corrected restored snapshot back to disk only after the
+      /// database restore has succeeded. This upgrades legacy metadata in-place
+      /// with the resolved sanitizedTitle and recomputed image paths, so future
+      /// reinstalls / device transfers no longer need to rediscover the old
+      /// naming compatibility case. A metadata write failure is logged by the
+      /// store and does not roll back an otherwise successful database restore.
+      final GalleryDownloadInfo restoredInfo = galleryDownloadInfos[gallery.gid]!;
+      await _flushMetadataSave(restoredInfo);
+
       /// The metadata-restore path loads every gallery's full image list
       /// (to derive curCount/hasDownloaded and the metadata snapshot). No
       /// consumer retains at startup, so evict completed galleries' lists
@@ -856,13 +887,66 @@ class GalleryDownloadService extends GetxController with GridBasePageServiceMixi
       /// (serialNo 0) resident for list/grid cover display; incomplete
       /// galleries keep their list for the download loop.
       if (gallery.downloadStatusIndex == DownloadStatus.downloaded.index) {
-        galleryDownloadInfos[gallery.gid]!.evictImages();
+        restoredInfo.evictImages();
       }
 
       restoredCount++;
     }
 
     return restoredCount;
+  }
+
+  /// Return true only for the stale-path shape created by the old restore bug:
+  /// an already-completed DB record points to a missing directory, while
+  /// the metadata being scanned resolves to an existing directory that
+  /// contains at least one of the restored image files.
+  bool _shouldRepairRestoredGalleryPath(
+    GalleryDownloadInfo existingGallery,
+    GalleryDownloadedData restoredGallery,
+    List<GalleryImage?> restoredImages,
+  ) {
+    if (existingGallery.downloadProgress.downloadStatus != DownloadStatus.downloaded) {
+      return false;
+    }
+
+    final String existingPath = path.normalize(
+      DownloadPathResolver.computeGalleryDownloadAbsolutePath(existingGallery.toGalleryDownloadedData()),
+    );
+    final String restoredPath = path.normalize(
+      DownloadPathResolver.computeGalleryDownloadAbsolutePath(restoredGallery),
+    );
+
+    if (existingPath == restoredPath || !io.Directory(restoredPath).existsSync()) {
+      return false;
+    }
+
+    /// A previous bad restore can later create the wrong directory just by
+    /// writing metadata (for example after changing a group or priority).
+    /// Directory existence alone therefore cannot prove the existing record is
+    /// usable. If its cover image is actually readable, however, leave it alone.
+    final String? existingCoverPath = existingGallery.coverImage?.path;
+    if (existingCoverPath != null) {
+      final io.File existingCover = io.File(
+        DownloadPathResolver.computeImageDownloadAbsolutePathFromRelativePath(existingCoverPath),
+      );
+      if (existingCover.existsSync()) {
+        return false;
+      }
+    }
+
+    for (final GalleryImage? image in restoredImages) {
+      final String? imagePath = image?.path;
+      if (imagePath == null) {
+        continue;
+      }
+      final io.File imageFile = io.File(
+        DownloadPathResolver.computeImageDownloadAbsolutePathFromRelativePath(imagePath),
+      );
+      if (imageFile.existsSync()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /// Re-compute every image's on-disk path after the user changes the download

--- a/lib/src/service/gallery_download/gallery_metadata_store.dart
+++ b/lib/src/service/gallery_download/gallery_metadata_store.dart
@@ -125,12 +125,18 @@ class _GalleryMetadataStore {
 
     GalleryDownloadedData gallery = GalleryDownloadedData.fromJson(raw['gallery']);
 
-    /// Back-fill sanitizedTitle for metadata files written before this field was introduced.
-    if (gallery.sanitizedTitle == null) {
-      final int reservedBytes = utf8.encode('${gallery.gid} - ').length;
-      gallery = gallery.copyWith(
-        sanitizedTitle: Value(DownloadPathResolver.computeSanitizedGalleryTitle(gallery.title, reservedBytes)),
-      );
+    /// The scanned directory is where the bytes actually live. Old metadata
+    /// has no sanitizedTitle, and metadata produced by an earlier buggy restore
+    /// may contain a title computed with the newer byte-based rule. Reconcile
+    /// both cases to the actual `{gid} - {title}` directory on disk.
+    final String restoredSanitizedTitle = DownloadPathResolver.resolveSanitizedGalleryTitleForRestore(
+      gid: gallery.gid,
+      rawTitle: gallery.title,
+      persistedSanitizedTitle: gallery.sanitizedTitle,
+      galleryDirectoryPath: galleryDir.path,
+    );
+    if (gallery.sanitizedTitle != restoredSanitizedTitle) {
+      gallery = gallery.copyWith(sanitizedTitle: Value(restoredSanitizedTitle));
     }
 
     List<GalleryImage?> images = (jsonDecode(raw['images']) as List).map((_map) => _map == null ? null : GalleryImage.fromJson(_map)).toList();

--- a/test/download_path_resolver_test.dart
+++ b/test/download_path_resolver_test.dart
@@ -1,0 +1,55 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jhentai/src/service/gallery_download/download_path_resolver.dart';
+
+void main() {
+  group('legacy gallery restore path', () {
+    test('uses the old 85-character truncation rule', () {
+      const String rawTitle =
+          '[Papaya Milk (Judith)] Maonaho ~Zenpen~ Maou o Mezasu Otouto ga Ore no Nama Onaho ni Natta Wake [Chinese]';
+
+      final String legacy = DownloadPathResolver.computeLegacySanitizedGalleryTitle(rawTitle);
+
+      expect(legacy.length, lessThanOrEqualTo(DownloadPathResolver.legacyGalleryTitleMaxChars));
+      expect(legacy, endsWith('Ore no Nama Onaho ni'));
+      expect(rawTitle.startsWith(legacy), isTrue);
+    });
+
+    test('prefers the scanned on-disk directory over a newer persisted title', () {
+      const int gid = 2059582;
+      const String rawTitle =
+          '[Papaya Milk (Judith)] Maonaho ~Zenpen~ Maou o Mezasu Otouto ga Ore no Nama Onaho ni Natta Wake [Chinese]';
+      final String legacy = DownloadPathResolver.computeLegacySanitizedGalleryTitle(rawTitle);
+      final int reservedBytes = utf8.encode('$gid - ').length;
+      final String newer = DownloadPathResolver.computeSanitizedGalleryTitle(rawTitle, reservedBytes);
+
+      expect(newer, isNot(legacy));
+
+      final String resolved = DownloadPathResolver.resolveSanitizedGalleryTitleForRestore(
+        gid: gid,
+        rawTitle: rawTitle,
+        persistedSanitizedTitle: newer,
+        galleryDirectoryPath: '/storage/emulated/0/JHenTai/download/$gid - $legacy',
+      );
+
+      expect(resolved, legacy);
+    });
+
+    test('falls back to legacy naming when old metadata is in a non-standard directory', () {
+      const int gid = 2059582;
+      const String rawTitle =
+          '[Papaya Milk (Judith)] Maonaho ~Zenpen~ Maou o Mezasu Otouto ga Ore no Nama Onaho ni Natta Wake [Chinese]';
+      final String legacy = DownloadPathResolver.computeLegacySanitizedGalleryTitle(rawTitle);
+
+      final String resolved = DownloadPathResolver.resolveSanitizedGalleryTitleForRestore(
+        gid: gid,
+        rawTitle: rawTitle,
+        persistedSanitizedTitle: null,
+        galleryDirectoryPath: '/storage/emulated/0/JHenTai/download/legacy-backup',
+      );
+
+      expect(resolved, legacy);
+    });
+  });
+}


### PR DESCRIPTION
修复旧版 metadata 恢复时，长标题画廊因目录命名规则变化导致整本图片无法读取的问题。

主要修改：

恢复时优先使用实际扫描到的画廊目录名，避免重新计算出的 sanitizedTitle 与磁盘目录不一致。
对没有 sanitizedTitle 的旧版 metadata 保留旧版 85 字符规则作为兼容。
修复已经错误恢复过一次的情况：如果已有记录指向不存在的目录，而实际扫描目录存在且包含图片，则重新恢复，而不是因为 gid 已存在直接跳过。
恢复成功后，将修正后的 sanitizedTitle 和图片路径重新写回 metadata，避免以后再次换设备时重复遇到同样的问题。
增加相关回归测试。

测试通过：

flutter analyze --no-fatal-infos
flutter test test/download_path_resolver_test.dart

Fixes #823